### PR TITLE
Implement mock OTP auth with i18n and role switching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,23 +7,29 @@ import MockProvider from "./components/MockProvider";
 import Index from "./pages/Index";
 import Offline from "./pages/Offline";
 import NotFound from "./pages/NotFound";
+import { SessionProvider } from "./context/SessionContext";
+import { I18nProvider } from "./context/I18nContext";
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <MockProvider />
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/offline" element={<Offline />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <I18nProvider>
+        <SessionProvider>
+          <MockProvider />
+          <Toaster />
+          <Sonner />
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/offline" element={<Offline />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </SessionProvider>
+      </I18nProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/auth/AuthStepIndicator.tsx
+++ b/src/components/auth/AuthStepIndicator.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/context/I18nContext';
+
+type AuthStep = 'contact' | 'otp' | 'role';
+
+type Props = {
+  current: AuthStep;
+};
+
+const steps: { id: Exclude<AuthStep, 'contact'>; order: number; labelKey: string }[] = [
+  { id: 'otp', order: 1, labelKey: 'auth.stepOne' },
+  { id: 'role', order: 2, labelKey: 'auth.stepTwo' },
+];
+
+export const AuthStepIndicator = ({ current }: Props) => {
+  const { t } = useI18n();
+
+  return (
+    <div className="flex items-center justify-center gap-3 text-sm font-medium text-muted-foreground">
+      {steps.map((step, index) => {
+        const isActive =
+          step.id === current || (step.id === 'otp' && (current === 'contact' || current === 'otp')) || (current === 'role' && step.id === 'otp');
+
+        return (
+          <div key={step.id} className="flex items-center gap-2">
+            <div
+              className={cn(
+                'flex h-7 w-7 items-center justify-center rounded-full border text-xs transition-colors',
+                isActive ? 'border-primary bg-primary text-primary-foreground' : 'border-border',
+              )}
+            >
+              {step.order}
+            </div>
+            <span className={cn('tracking-tight', isActive ? 'text-foreground' : 'text-muted-foreground')}>
+              {t(step.labelKey)}
+            </span>
+            {index < steps.length - 1 && <span className="text-muted-foreground">•</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/auth/RoleChooser.tsx
+++ b/src/components/auth/RoleChooser.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { ShoppingBag, Boxes } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AuthStepIndicator } from './AuthStepIndicator';
+import { useI18n } from '@/context/I18nContext';
+import type { Session } from '@/types';
+import { trackEvent } from '@/lib/analytics';
+
+type Role = Session['role'];
+
+type RoleChooserProps = {
+  initialRole: Role;
+  onRoleChosen: (role: Role) => void;
+};
+
+const options: { role: Role; titleKey: string; descriptionKey: string; summaryKey: string; icon: typeof ShoppingBag }[] = [
+  {
+    role: 'buyer',
+    titleKey: 'roles.buyerTitle',
+    descriptionKey: 'roles.buyerSubtitle',
+    summaryKey: 'roles.buyerSummary',
+    icon: ShoppingBag,
+  },
+  {
+    role: 'importer',
+    titleKey: 'roles.importerTitle',
+    descriptionKey: 'roles.importerSubtitle',
+    summaryKey: 'roles.importerSummary',
+    icon: Boxes,
+  },
+];
+
+export const RoleChooser = ({ initialRole, onRoleChosen }: RoleChooserProps) => {
+  const { t } = useI18n();
+  const [selected, setSelected] = useState<Role>(initialRole);
+
+  const handleContinue = () => {
+    trackEvent('role_select', { role: selected, source: 'onboarding' });
+    onRoleChosen(selected);
+  };
+
+  return (
+    <main className="min-h-dvh bg-background text-foreground">
+      <div className="mx-auto flex min-h-dvh w-full max-w-xl flex-col gap-8 px-6 py-10">
+        <AuthStepIndicator current="role" />
+
+        <header className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">{t('roles.prompt')}</h1>
+          <p className="text-muted-foreground">{t('roles.description')}</p>
+        </header>
+
+        <div className="grid gap-4">
+          {options.map(option => {
+            const Icon = option.icon;
+            const isActive = selected === option.role;
+            return (
+              <button
+                key={option.role}
+                type="button"
+                onClick={() => setSelected(option.role)}
+                className={`flex items-center gap-4 rounded-2xl border-2 p-4 text-left transition-all ${
+                  isActive ? 'border-primary bg-primary/5 shadow-sm' : 'border-border'
+                }`}
+              >
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <Icon className="h-7 w-7" />
+                </div>
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold">{t(option.titleKey)}</h2>
+                    {isActive && <span className="rounded-full bg-primary px-2 py-0.5 text-xs text-primary-foreground">✔</span>}
+                  </div>
+                  <p className="text-sm text-muted-foreground">{t(option.descriptionKey)}</p>
+                  <p className="text-sm font-medium text-muted-foreground/80">{t(option.summaryKey)}</p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <Button onClick={handleContinue} className="h-12 rounded-xl text-base font-semibold">
+          {t('common.continue')}
+        </Button>
+      </div>
+    </main>
+  );
+};

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -1,0 +1,232 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { trackEvent } from '@/lib/analytics';
+
+type Locale = 'en' | 'fr';
+
+const translations = {
+  en: {
+    app: {
+      name: 'ProList Mini',
+      tagline: 'Fast preorder companion',
+    },
+    common: {
+      continue: 'Continue',
+      account: 'Account',
+      signOut: 'Sign out',
+      changeLanguage: 'Change language',
+      language: 'Language',
+      cancel: 'Cancel',
+      close: 'Close',
+    },
+    auth: {
+      welcome: 'Welcome to ProList Mini',
+      intro: 'Sign in with your phone number or email to get started.',
+      contactLabel: 'Phone or email',
+      contactPlaceholder: 'Enter your phone number or email',
+      contactHint: 'Enter phone or email',
+      sendCode: 'Send code',
+      sendDisabled: 'Connect to the internet to request a code.',
+      useDemo: 'Use demo account',
+      offlineBanner: "You're offline. Use the demo account to keep exploring.",
+      stepOne: '1/2 Verify',
+      stepTwo: '2/2 Choose role',
+      otpTitle: 'Enter the 6-digit code',
+      otpSubtitle: "We\'ve sent a 6-digit code to {{contact}}.",
+      verifyCta: 'Verify code',
+      wrongCode: 'Wrong code. Try again.',
+      resendIn: 'Resend in {{time}}',
+      resendNow: 'Resend code',
+      changeContact: 'Change contact',
+      codeLabel: 'One-time code',
+    },
+    roles: {
+      prompt: 'How do you want to use ProList Mini today?',
+      description: 'Pick the workspace you need right now — you can switch anytime.',
+      buyerTitle: 'Buyer',
+      buyerSubtitle: 'Shop listings and track pooled orders.',
+      importerTitle: 'Importer',
+      importerSubtitle: 'Create drops and manage preorder pools.',
+      buyerBadge: 'Buyer mode',
+      importerBadge: 'Importer mode',
+      buyerSummary: 'Browse curated products and keep an eye on pooled shipments.',
+      importerSummary: 'Launch preorder pools, monitor commitments, and prep paperwork.',
+      switchTitle: 'Switch role',
+      switchNote: 'Tap a mode to jump right in — updates instantly.',
+    },
+    dashboard: {
+      buyerHeading: 'Buyer home',
+      buyerWelcome: 'Good to see you, {{name}}.',
+      buyerActionsTitle: 'Quick actions',
+      buyerActionBrowse: 'Browse listings',
+      buyerActionTrack: 'Track orders',
+      buyerActionSupport: 'Request support',
+      importerHeading: 'Importer dashboard',
+      importerWelcome: 'Welcome back, {{name}}.',
+      importerStatusVerified: 'Verified Importer',
+      importerStatusPending: 'Verification pending',
+      importerActionsTitle: 'Next steps',
+      importerActionCreate: 'Create preorder',
+      importerActionReview: 'Review commitments',
+      importerActionDocs: 'Upload documents',
+      statusTitle: 'Status overview',
+      buyerStatusPool: 'Pools joined',
+      buyerStatusDeliveries: 'Deliveries this month',
+      buyerStatusWallet: 'Wallet balance',
+      importerStatusActive: 'Active pools',
+      importerStatusLogistics: 'Shipments in transit',
+      importerStatusBalance: 'Escrow balance',
+    },
+  },
+  fr: {
+    app: {
+      name: 'ProList Mini',
+      tagline: 'Compagnon de précommande rapide',
+    },
+    common: {
+      continue: 'Continuer',
+      account: 'Compte',
+      signOut: 'Se déconnecter',
+      changeLanguage: 'Changer de langue',
+      language: 'Langue',
+      cancel: 'Annuler',
+      close: 'Fermer',
+    },
+    auth: {
+      welcome: 'Bienvenue sur ProList Mini',
+      intro: 'Connectez-vous avec votre numéro ou votre email pour démarrer.',
+      contactLabel: 'Téléphone ou email',
+      contactPlaceholder: 'Saisissez votre téléphone ou votre email',
+      contactHint: 'Saisissez votre téléphone ou votre email',
+      sendCode: 'Envoyer le code',
+      sendDisabled: 'Connectez-vous à internet pour demander un code.',
+      useDemo: 'Utiliser le compte démo',
+      offlineBanner: "Vous êtes hors connexion. Utilisez le compte démo pour continuer.",
+      stepOne: '1/2 Vérifier',
+      stepTwo: '2/2 Choisir le rôle',
+      otpTitle: 'Entrez le code à 6 chiffres',
+      otpSubtitle: 'Nous avons envoyé un code à 6 chiffres à {{contact}}.',
+      verifyCta: 'Valider le code',
+      wrongCode: 'Code incorrect. Réessayez.',
+      resendIn: 'Renvoyer dans {{time}}',
+      resendNow: 'Renvoyer le code',
+      changeContact: 'Modifier le contact',
+      codeLabel: 'Code à usage unique',
+    },
+    roles: {
+      prompt: 'Comment souhaitez-vous utiliser ProList Mini aujourd\'hui ?',
+      description: 'Choisissez l\'espace de travail voulu — vous pourrez changer ensuite.',
+      buyerTitle: 'Acheteur',
+      buyerSubtitle: 'Achetez des offres et suivez vos commandes groupées.',
+      importerTitle: 'Importateur',
+      importerSubtitle: 'Créez des drops et gérez les précommandes.',
+      buyerBadge: 'Mode Acheteur',
+      importerBadge: 'Mode Importateur',
+      buyerSummary: 'Parcourez les produits et surveillez vos expéditions groupées.',
+      importerSummary: 'Lancez des précommandes, suivez les engagements et préparez les dossiers.',
+      switchTitle: 'Changer de mode',
+      switchNote: 'Touchez un mode pour y accéder immédiatement — mise à jour instantanée.',
+    },
+    dashboard: {
+      buyerHeading: 'Accueil Acheteur',
+      buyerWelcome: 'Ravi de vous revoir, {{name}}.',
+      buyerActionsTitle: 'Actions rapides',
+      buyerActionBrowse: 'Voir les offres',
+      buyerActionTrack: 'Suivre les commandes',
+      buyerActionSupport: 'Contacter le support',
+      importerHeading: 'Tableau Importateur',
+      importerWelcome: 'Bon retour, {{name}}.',
+      importerStatusVerified: 'Importateur vérifié',
+      importerStatusPending: 'Vérification en cours',
+      importerActionsTitle: 'Étapes suivantes',
+      importerActionCreate: 'Créer une précommande',
+      importerActionReview: 'Revoir les engagements',
+      importerActionDocs: 'Téléverser des documents',
+      statusTitle: 'Vue d\'ensemble',
+      buyerStatusPool: 'Pools rejoints',
+      buyerStatusDeliveries: 'Livraisons ce mois-ci',
+      buyerStatusWallet: 'Solde portefeuille',
+      importerStatusActive: 'Pools actifs',
+      importerStatusLogistics: 'Expéditions en transit',
+      importerStatusBalance: 'Solde en séquestre',
+    },
+  },
+} as const;
+
+type TranslationDict = (typeof translations)['en'];
+
+type InterpolationValues = Record<string, string | number>;
+
+type I18nContextValue = {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string, vars?: InterpolationValues) => string;
+};
+
+const STORAGE_KEY = 'pl.locale';
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+const getPreferredLocale = (): Locale => {
+  if (typeof window === 'undefined') return 'en';
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'en' || stored === 'fr') return stored;
+  const browser = window.navigator.language?.slice(0, 2).toLowerCase();
+  if (browser === 'fr') return 'fr';
+  return 'en';
+};
+
+const resolve = (dict: TranslationDict, key: string): string | undefined => {
+  return key.split('.').reduce<unknown>((acc, segment) => {
+    if (acc && typeof acc === 'object' && segment in (acc as Record<string, unknown>)) {
+      return (acc as Record<string, unknown>)[segment];
+    }
+    return undefined;
+  }, dict) as string | undefined;
+};
+
+const format = (template: string, vars?: InterpolationValues) => {
+  if (!vars) return template;
+  return template.replace(/\{\{(.*?)\}\}/g, (_, token) => {
+    const value = vars[token.trim()];
+    return value !== undefined ? String(value) : '';
+  });
+};
+
+export const I18nProvider = ({ children }: { children: React.ReactNode }) => {
+  const [locale, setLocaleState] = useState<Locale>(() => getPreferredLocale());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(STORAGE_KEY, locale);
+  }, [locale]);
+
+  const setLocale = useCallback((next: Locale) => {
+    setLocaleState(prev => {
+      if (prev === next) return prev;
+      trackEvent('lang_change', { locale: next });
+      return next;
+    });
+  }, []);
+
+  const t = useCallback(
+    (key: string, vars?: InterpolationValues) => {
+      const primary = resolve(translations[locale], key);
+      if (primary) return format(primary, vars);
+      const fallback = resolve(translations.en, key);
+      return fallback ? format(fallback, vars) : key;
+    },
+    [locale],
+  );
+
+  const value = useMemo(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+};
+
+export const useI18n = () => {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within I18nProvider');
+  }
+  return context;
+};

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { Session } from '@/types';
+
+const STORAGE_KEY = 'pl.session';
+
+type SessionContextValue = {
+  session: Session | null;
+  setSession: (value: Session) => void;
+  clearSession: () => void;
+  updateSession: (updater: (current: Session) => Session) => void;
+};
+
+const SessionContext = createContext<SessionContextValue | undefined>(undefined);
+
+export const SessionProvider = ({ children }: { children: React.ReactNode }) => {
+  const [session, setSessionState] = useState<Session | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Session;
+      setSessionState(parsed);
+    } catch (error) {
+      console.error('Failed to restore session', error);
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const setSession = useCallback((value: Session) => {
+    setSessionState(value);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    }
+  }, []);
+
+  const clearSession = useCallback(() => {
+    setSessionState(null);
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const updateSession = useCallback((updater: (current: Session) => Session) => {
+    setSessionState(prev => {
+      if (!prev) return prev;
+      const next = updater(prev);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      session,
+      setSession,
+      clearSession,
+      updateSession,
+    }),
+    [session, setSession, clearSession, updateSession],
+  );
+
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+};
+
+export const useSession = () => {
+  const context = useContext(SessionContext);
+  if (!context) {
+    throw new Error('useSession must be used within SessionProvider');
+  }
+  return context;
+};

--- a/src/hooks/use-network-status.ts
+++ b/src/hooks/use-network-status.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export const useNetworkStatus = () => {
+  const [isOnline, setIsOnline] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return window.navigator.onLine;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+};

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,15 @@
+export type AppEvent =
+  | 'auth_start'
+  | 'auth_code_sent'
+  | 'auth_success'
+  | 'auth_fail'
+  | 'role_select'
+  | 'role_switch'
+  | 'lang_change';
+
+export function trackEvent<T extends AppEvent>(name: T, payload?: Record<string, unknown>) {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.info(`[event] ${name}`, payload ?? {});
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,111 +1,308 @@
-import { ListChecks, Shield, Clock, MapPin } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { api } from '@/lib/api';
+import { useMemo, useState } from 'react';
+import { Languages, UserRound, ChevronRight } from 'lucide-react';
+import { SignInFlow } from '@/components/auth/SignInFlow';
+import { RoleChooser } from '@/components/auth/RoleChooser';
+import { useSession } from '@/context/SessionContext';
+import { useI18n } from '@/context/I18nContext';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import type { Session } from '@/types';
+import { cn } from '@/lib/utils';
+import { trackEvent } from '@/lib/analytics';
 
-const Index = () => {
-  const [apiTest, setApiTest] = useState<{ status: string; data?: any }>({ status: 'loading' });
+const languageNames: Record<'en' | 'fr', string> = {
+  en: 'English',
+  fr: 'Français',
+};
 
-  useEffect(() => {
-    // Test MSW API
-    api('/api/listings')
-      .then(data => setApiTest({ status: 'success', data }))
-      .catch(error => setApiTest({ status: 'error', data: error.message }));
-  }, []);
+type Role = Session['role'];
+
+const LanguageToggle = ({ className }: { className?: string }) => {
+  const { locale, setLocale, t } = useI18n();
+  const nextLocale = locale === 'en' ? 'fr' : 'en';
 
   return (
-    <main className="min-h-dvh bg-bg text-fg antialiased">
-      <div className="max-w-md mx-auto p-4 space-y-6">
-        
-        {/* Header */}
-        <header className="text-center py-6">
-          <div className="mb-4 flex justify-center">
-            <div className="w-16 h-16 bg-primary rounded-2xl flex items-center justify-center shadow-soft">
-              <ListChecks className="w-8 h-8 text-white" />
+    <Button
+      variant="outline"
+      size="sm"
+      className={cn('h-10 rounded-full border-primary/40 px-4 text-xs font-semibold uppercase', className)}
+      onClick={() => setLocale(nextLocale)}
+      aria-label={t('common.changeLanguage')}
+    >
+      <Languages className="h-4 w-4" />
+      <span>{locale.toUpperCase()}</span>
+      <span className="hidden text-muted-foreground sm:inline">{t('common.changeLanguage')}</span>
+    </Button>
+  );
+};
+
+const AccountSheet = ({ session }: { session: Session }) => {
+  const { t, locale } = useI18n();
+  const { updateSession } = useSession();
+  const [open, setOpen] = useState(false);
+
+  const handleRoleChange = (role: Role) => {
+    if (session.role === role) return;
+    updateSession(current => ({ ...current, role, hasSelectedRole: true }));
+    trackEvent('role_switch', { role });
+    setOpen(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-10 w-10 rounded-full border border-border bg-background shadow-sm"
+        >
+          <UserRound className="h-5 w-5" />
+          <span className="sr-only">{t('common.account')}</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex w-full flex-col gap-6 sm:max-w-sm">
+        <SheetHeader className="space-y-1 text-left">
+          <SheetTitle>{t('common.account')}</SheetTitle>
+          <SheetDescription>{session.contact}</SheetDescription>
+        </SheetHeader>
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('roles.switchTitle')}
+          </h3>
+          <p className="text-sm text-muted-foreground">{t('roles.switchNote')}</p>
+          <div className="grid gap-3">
+            <AccountRoleOption
+              active={session.role === 'buyer'}
+              label={t('roles.buyerBadge')}
+              description={t('roles.buyerSummary')}
+              onClick={() => handleRoleChange('buyer')}
+            />
+            <AccountRoleOption
+              active={session.role === 'importer'}
+              label={t('roles.importerBadge')}
+              description={t('roles.importerSummary')}
+              onClick={() => handleRoleChange('importer')}
+            />
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('common.language')}
+          </h3>
+          <p className="text-sm text-muted-foreground">{languageNames[locale]}</p>
+          <LanguageToggle className="w-full justify-center" />
+        </section>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+type AccountRoleOptionProps = {
+  active: boolean;
+  label: string;
+  description: string;
+  onClick: () => void;
+};
+
+const AccountRoleOption = ({ active, label, description, onClick }: AccountRoleOptionProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      'flex items-start justify-between rounded-2xl border-2 p-4 text-left transition-all',
+      active ? 'border-primary bg-primary/5 shadow-sm' : 'border-border hover:border-primary/50',
+    )}
+  >
+    <div className="space-y-1">
+      <p className="text-sm font-semibold text-foreground">{label}</p>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+    <ChevronRight className="h-5 w-5 text-muted-foreground" />
+  </button>
+);
+
+const BuyerHome = ({ session }: { session: Session }) => {
+  const { t } = useI18n();
+
+  const stats = useMemo(
+    () => [
+      { label: t('dashboard.buyerStatusPool'), value: '3' },
+      { label: t('dashboard.buyerStatusDeliveries'), value: '2' },
+      { label: t('dashboard.buyerStatusWallet'), value: '180,000 XAF' },
+    ],
+    [t],
+  );
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl bg-gradient-to-br from-primary/15 via-primary/5 to-background p-6 shadow-sm">
+        <h2 className="text-xl font-semibold tracking-tight">
+          {t('dashboard.buyerWelcome', { name: session.displayName })}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">{t('roles.buyerSummary')}</p>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('dashboard.buyerActionsTitle')}
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Button variant="secondary" className="h-12 rounded-xl justify-between">
+            {t('dashboard.buyerActionBrowse')}
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+          <Button variant="secondary" className="h-12 rounded-xl justify-between">
+            {t('dashboard.buyerActionTrack')}
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+          <Button variant="secondary" className="h-12 rounded-xl justify-between">
+            {t('dashboard.buyerActionSupport')}
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('dashboard.statusTitle')}
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {stats.map(stat => (
+            <div key={stat.label} className="rounded-2xl border border-border p-4 shadow-sm">
+              <p className="text-2xl font-semibold text-foreground">{stat.value}</p>
+              <p className="text-xs text-muted-foreground">{stat.label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const ImporterDashboard = ({ session }: { session: Session }) => {
+  const { t } = useI18n();
+
+  const stats = useMemo(
+    () => [
+      { label: t('dashboard.importerStatusActive'), value: '2' },
+      { label: t('dashboard.importerStatusLogistics'), value: '1' },
+      { label: t('dashboard.importerStatusBalance'), value: '520,000 XAF' },
+    ],
+    [t],
+  );
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl bg-gradient-to-br from-emerald-100/40 via-background to-background p-6 shadow-sm">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold tracking-tight">
+            {t('dashboard.importerWelcome', { name: session.displayName })}
+          </h2>
+          <Badge variant={session.verifiedImporter ? 'default' : 'secondary'}>
+            {session.verifiedImporter ? t('dashboard.importerStatusVerified') : t('dashboard.importerStatusPending')}
+          </Badge>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">{t('roles.importerSummary')}</p>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('dashboard.importerActionsTitle')}
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Button variant="secondary" className="h-12 rounded-xl justify-between">
+            {t('dashboard.importerActionCreate')}
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+          <Button variant="secondary" className="h-12 rounded-xl justify-between">
+            {t('dashboard.importerActionReview')}
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+          <Button variant="secondary" className="h-12 rounded-xl justify-between">
+            {t('dashboard.importerActionDocs')}
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('dashboard.statusTitle')}
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {stats.map(stat => (
+            <div key={stat.label} className="rounded-2xl border border-border p-4 shadow-sm">
+              <p className="text-2xl font-semibold text-foreground">{stat.value}</p>
+              <p className="text-xs text-muted-foreground">{stat.label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const AuthenticatedShell = ({ session }: { session: Session }) => {
+  const { t, locale } = useI18n();
+  const modeLabel = session.role === 'buyer' ? t('roles.buyerBadge') : t('roles.importerBadge');
+
+  return (
+    <main className="min-h-dvh bg-background text-foreground">
+      <div className="mx-auto flex min-h-dvh w-full max-w-3xl flex-col gap-8 px-6 py-10">
+        <header className="flex flex-col gap-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase text-primary/80">{t('app.tagline')}</p>
+              <h1 className="text-3xl font-bold tracking-tight text-foreground">{t('app.name')}</h1>
+            </div>
+            <div className="flex items-center gap-3">
+              <LanguageToggle />
+              <AccountSheet session={session} />
             </div>
           </div>
-          <h1 className="text-2xl font-bold text-fg">ProList Mini</h1>
-          <p className="mt-2 text-muted">Installable PWA scaffold. Tokens loaded.</p>
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge variant="outline" className="rounded-full border-primary/60 bg-primary/10 px-3 py-1 text-primary">
+              {modeLabel}
+            </Badge>
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {languageNames[locale]}
+            </span>
+          </div>
         </header>
 
-        {/* API Test */}
-        <section className="bg-card border border-border rounded-xl p-4">
-          <h2 className="text-lg font-semibold mb-3">MSW API Test</h2>
-          {apiTest.status === 'loading' && (
-            <p className="text-muted">Testing /api/listings...</p>
-          )}
-          {apiTest.status === 'success' && (
-            <div className="space-y-2">
-              <p className="text-green-600 font-semibold">✅ MSW API Working!</p>
-              <p className="text-sm text-muted">
-                Found {apiTest.data?.items?.length || 0} listings
-              </p>
-              {apiTest.data?.items?.[0] && (
-                <div className="bg-primary/5 border border-primary/20 rounded-lg p-3 mt-2">
-                  <p className="font-medium">{apiTest.data.items[0].title}</p>
-                  <p className="text-sm text-muted">{apiTest.data.items[0].priceXAF} XAF</p>
-                </div>
-              )}
-            </div>
-          )}
-          {apiTest.status === 'error' && (
-            <div className="text-red-600">
-              <p className="font-semibold">❌ API Error</p>
-              <p className="text-sm">{apiTest.data}</p>
-            </div>
-          )}
-        </section>
-
-        {/* Demo Components */}
-        <section className="space-y-4">
-          <h2 className="text-lg font-semibold">Component Demo</h2>
-          
-          {/* Buttons */}
-          <div className="grid gap-3">
-            <button className="btn-primary">
-              <Shield className="w-4 h-4 mr-2" />
-              Primary Action
-            </button>
-            <button className="btn-outline">
-              <Clock className="w-4 h-4 mr-2" />
-              Secondary Action
-            </button>
-          </div>
-          
-          {/* Chips/Tags */}
-          <div className="space-y-2">
-            <div className="chip chip-escrow">
-              <Shield className="w-4 h-4" />
-              Protected by Escrow
-            </div>
-            <div className="chip chip-lane">
-              <MapPin className="w-4 h-4" />
-              GZ→DLA • 93% on-time
-            </div>
-            <div className="chip chip-timer">
-              <Clock className="w-4 h-4" />
-              48h remaining
-            </div>
-          </div>
-          
-          {/* Card Example */}
-          <div className="bg-card border border-border rounded-2xl p-4 shadow-card">
-            <h3 className="font-semibold text-fg mb-2">Sample Order</h3>
-            <p className="text-muted text-sm mb-3">Mobile-first responsive design with design tokens.</p>
-            <div className="flex justify-between items-center">
-              <span className="chip chip-escrow">Secured</span>
-              <span className="font-bold text-primary">$49.99</span>
-            </div>
-          </div>
-        </section>
-
-        {/* PWA Install Note */}
-        <section className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
-          <h3 className="font-semibold text-primary mb-2">PWA Ready</h3>
-          <p className="text-sm text-muted">This app can be installed on your device for a native experience.</p>
-        </section>
+        {session.role === 'buyer' ? <BuyerHome session={session} /> : <ImporterDashboard session={session} />}
       </div>
     </main>
   );
+};
+
+const Index = () => {
+  const { session, setSession, updateSession } = useSession();
+
+  if (!session) {
+    return <SignInFlow onAuthenticated={setSession} />;
+  }
+
+  if (!session.hasSelectedRole) {
+    return (
+      <RoleChooser
+        initialRole={session.role}
+        onRoleChosen={role => updateSession(current => ({ ...current, role, hasSelectedRole: true }))}
+      />
+    );
+  }
+
+  return <AuthenticatedShell session={session} />;
 };
 
 export default Index;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,9 @@ export type PickupPoint = {
 
 export type Session = {
   userId: string;
-  role: 'buyer' | 'importer' | 'admin';
-  token: string;
+  displayName: string;
+  contact: string;
+  role: 'buyer' | 'importer';
+  hasSelectedRole: boolean;
+  verifiedImporter: boolean;
 };


### PR DESCRIPTION
## Summary
- introduce i18n and session providers with persistent locale/session storage plus console-based analytics hooks
- build the OTP sign-in flow with resend timer, offline banner, and demo shortcut that emits required auth events
- add role selection and authenticated dashboards featuring buyer/importer content, language toggle, and account-based role switching

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies could not be installed in this environment)*
- npm run build *(fails: vite missing for the same dependency-installation restriction; npm install returned 403 on ajv)*

------
https://chatgpt.com/codex/tasks/task_e_68d1867686588324a7f765c6c8f5207e