### PR TITLE
Fix checkout page crash from effect ordering

### DIFF
--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -74,16 +74,6 @@ const Checkout = () => {
   }, [listingId, locationState]);
 
   useEffect(() => {
-    if (!initialisedRef.current) return;
-    setCheckoutDraft({
-      listingId: effectiveListingId,
-      qty,
-      pickupPointId: selectedPickupId ?? undefined,
-      paymentMethod: paymentMethod ?? undefined,
-    });
-  }, [effectiveListingId, qty, paymentMethod, selectedPickupId]);
-
-  useEffect(() => {
     if (selectedPickupId) {
       setLastPickupId(selectedPickupId);
     }
@@ -144,6 +134,16 @@ const Checkout = () => {
   }, [pickupOptions, selectedPickupId]);
 
   const effectiveListingId = listing?.id ?? listingId ?? primaryDemoListing.id;
+
+  useEffect(() => {
+    if (!initialisedRef.current) return;
+    setCheckoutDraft({
+      listingId: effectiveListingId,
+      qty,
+      pickupPointId: selectedPickupId ?? undefined,
+      paymentMethod: paymentMethod ?? undefined,
+    });
+  }, [effectiveListingId, qty, paymentMethod, selectedPickupId]);
 
   useEffect(() => {
     if (listing) {


### PR DESCRIPTION
## Summary
- move checkout draft persistence effect so it runs after the effective listing id is defined
- prevent the Checkout page from throwing a ReferenceError that rendered the checkout and payment views blank

## Testing
- npm install *(fails: registry returned 403 for multiple packages)*
- bun install *(fails: registry returned 403 for multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d1dde97a1083248c3c5caf3feded2b