### PR TITLE
Ensure MSW is ready before rendering app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,23 +23,24 @@ const App = () => (
     <TooltipProvider>
       <I18nProvider>
         <SessionProvider>
-          <MockProvider />
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/listings/:id" element={<ListingDetails />} />
-              <Route path="/checkout/:listingId" element={<Checkout />} />
-              <Route path="/checkout/return" element={<CheckoutReturn />} />
-              <Route path="/order/:id" element={<OrderTracker />} />
-              <Route path="/order/:id/qr" element={<OrderPickupQr />} />
-              <Route path="/mock/psp" element={<MockPsp />} />
-              <Route path="/offline" element={<Offline />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
+          <MockProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/listings/:id" element={<ListingDetails />} />
+                <Route path="/checkout/:listingId" element={<Checkout />} />
+                <Route path="/checkout/return" element={<CheckoutReturn />} />
+                <Route path="/order/:id" element={<OrderTracker />} />
+                <Route path="/order/:id/qr" element={<OrderPickupQr />} />
+                <Route path="/mock/psp" element={<MockPsp />} />
+                <Route path="/offline" element={<Offline />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </MockProvider>
         </SessionProvider>
       </I18nProvider>
     </TooltipProvider>


### PR DESCRIPTION
## Summary
- update `MockProvider` to render children only after the mock service worker is ready and handle startup failures gracefully
- wrap the application shell with the updated provider so API requests wait for MSW during development

## Testing
- ⚠️ `npm run lint` *(fails: npm could not download dependencies from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e0e70fec8324b93dba1a0fff70b4