### PR TITLE
Collapse home feed sort and category controls

### DIFF
--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -23,6 +23,7 @@ const translations = {
       searchLaneLabel: '{{mode}} • {{pct}}% on-time',
       heroCopy: 'Protected by Escrow · Auto-refund if late',
       categoriesAll: 'All categories',
+      categoriesMenu: 'Browse categories',
       resultsCount: '{{count}} results',
       demoData: 'Demo data',
       pullToRefresh: 'Pull to refresh',
@@ -50,6 +51,7 @@ const translations = {
       pillEta: 'ETA {{min}}–{{max}} days',
       pillPrice: 'Price {{min}} – {{max}}',
       removeFilter: 'Remove {{label}}',
+      sortMenu: 'Sort options',
       sort: {
         relevance: 'Relevance',
         endingSoon: 'Ending soon',
@@ -343,6 +345,7 @@ const translations = {
       searchLaneLabel: '{{mode}} • {{pct}}% ponctuel',
       heroCopy: 'Protégé par séquestre · Remboursement automatique en cas de retard',
       categoriesAll: 'Toutes les catégories',
+      categoriesMenu: 'Parcourir les catégories',
       resultsCount: '{{count}} résultats',
       demoData: 'Données démo',
       pullToRefresh: 'Tirer pour actualiser',
@@ -370,6 +373,7 @@ const translations = {
       pillEta: 'ETA {{min}}–{{max}} jours',
       pillPrice: 'Prix {{min}} – {{max}}',
       removeFilter: 'Retirer {{label}}',
+      sortMenu: 'Options de tri',
       sort: {
         relevance: 'Pertinence',
         endingSoon: 'Se termine bientôt',


### PR DESCRIPTION
## Summary
- replace the horizontal sorting and category rows on the home feed with compact icon popovers that reveal the previous options
- keep filter chips but group the popover triggers with the search bar for a cleaner header layout
- add translation strings for the new popover labels in both English and French

## Testing
- `npm run lint` *(fails: @eslint/js missing because npm install cannot download ajv from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f04518bc832493278148382f02f1