### PR TITLE
Fix Sonner toaster theme without next-themes

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,14 +1,11 @@
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, toast } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="system"
       className="toaster group"
       toastOptions={{
         classNames: {


### PR DESCRIPTION
## Summary
- prevent the Sonner toaster component from calling `useTheme` so it no longer depends on `next-themes`
- default the toast theme to `system`, eliminating the runtime crash that blanked out the deployed page

## Testing
- not run (npm install fails with 403 errors in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d24269e5e48324b61a697bd0b2a7fd