### PR TITLE
Fix share sheet hook usage to prevent blank page

### DIFF
--- a/src/components/share/ShareSheet.tsx
+++ b/src/components/share/ShareSheet.tsx
@@ -155,8 +155,8 @@ const ShareSheet = ({ open, onOpenChange, ...rest }: ShareSheetProps) => {
     });
   }, [locale, open, isOnline, props.context, props.data, template, toast, t, useShortLink]);
 
-  const priceLabel = listingData ? usePriceLabel(locale, listingData.priceXAF) : '';
-  const onTimeLabel = listingData ? usePercentLabel(listingData.onTimePct) : '';
+  const priceLabel = usePriceLabel(locale, listingData?.priceXAF ?? 0);
+  const onTimeLabel = usePercentLabel(listingData?.onTimePct ?? 0);
 
   const logShareAttempt = () => {
     const now = Date.now();


### PR DESCRIPTION
## Summary
- ensure the share sheet always calls its memoized formatting helpers so React's hook order stays stable and the app renders normally

## Testing
- npm install *(fails: 403 Forbidden while fetching ajv from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d252ab70688324802021e6f67104af