### PR TITLE
Guard session persistence against storage errors

### DIFF
--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -31,14 +31,22 @@ export const SessionProvider = ({ children }: { children: React.ReactNode }) => 
   const setSession = useCallback((value: Session) => {
     setSessionState(value);
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      } catch (error) {
+        console.error('Failed to persist session', error);
+      }
     }
   }, []);
 
   const clearSession = useCallback(() => {
     setSessionState(null);
     if (typeof window !== 'undefined') {
-      window.localStorage.removeItem(STORAGE_KEY);
+      try {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } catch (error) {
+        console.error('Failed to clear session', error);
+      }
     }
   }, []);
 
@@ -47,7 +55,11 @@ export const SessionProvider = ({ children }: { children: React.ReactNode }) => 
       if (!prev) return prev;
       const next = updater(prev);
       if (typeof window !== 'undefined') {
-        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch (error) {
+          console.error('Failed to persist session', error);
+        }
       }
       return next;
     });


### PR DESCRIPTION
## Summary
- wrap session persistence helpers with try/catch so storage failures (e.g. blocked localStorage) no longer crash the app
- log meaningful console errors when persisting or clearing the session fails, while keeping in-memory state updated

## Testing
- Not run (npm dependencies cannot be installed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d255490e5c8324924ac49963664b1c