### PR TITLE
Fix base path handling for GitHub Pages deployments

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,49 +4,80 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 import { VitePWA } from "vite-plugin-pwa";
 
+const ensureLeadingSlash = (value: string) => (value.startsWith("/") ? value : `/${value}`);
+const ensureTrailingSlash = (value: string) => (value.endsWith("/") ? value : `${value}/`);
+
+const resolveBasePath = () => {
+  const explicitBase = process.env.VITE_BASE_PATH ?? process.env.BASE_PATH;
+  if (explicitBase && explicitBase !== ".") {
+    if (explicitBase === "/") {
+      return "/";
+    }
+    return ensureTrailingSlash(ensureLeadingSlash(explicitBase));
+  }
+
+  const repository = process.env.GITHUB_REPOSITORY;
+  const isGithubPages = Boolean(process.env.GITHUB_PAGES ?? process.env.GITHUB_ACTIONS);
+
+  if (repository && isGithubPages) {
+    const [, repoName = ""] = repository.split("/");
+    if (repoName) {
+      return ensureTrailingSlash(ensureLeadingSlash(repoName));
+    }
+  }
+
+  return "/";
+};
+
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(), 
-    mode === "development" && componentTagger(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,avif}']
-      },
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'icon-192.png', 'icon-512.png'],
-      manifest: {
-        name: 'ProList_Mini Importation',
-        short_name: 'ProList Mini',
-        description: 'Trust-first preorder app with escrow, countdown and pickup QR.',
-        theme_color: '#0FBF6D',
-        background_color: '#ffffff',
-        display: 'standalone',
-        start_url: '/',
-        icons: [
-          {
-            src: 'icon-192.png',
-            sizes: '192x192',
-            type: 'image/png',
-            purpose: 'any maskable'
-          },
-          {
-            src: 'icon-512.png', 
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any maskable'
-          }
-        ]
-      }
-    })
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const base = resolveBasePath();
+
+  return {
+    base,
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react(),
+      mode === "development" && componentTagger(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        workbox: {
+          globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,avif}']
+        },
+        includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'icon-192.png', 'icon-512.png'],
+        manifest: {
+          name: 'ProList_Mini Importation',
+          short_name: 'ProList Mini',
+          description: 'Trust-first preorder app with escrow, countdown and pickup QR.',
+          theme_color: '#0FBF6D',
+          background_color: '#ffffff',
+          display: 'standalone',
+          start_url: base,
+          scope: base,
+          icons: [
+            {
+              src: 'icon-192.png',
+              sizes: '192x192',
+              type: 'image/png',
+              purpose: 'any maskable'
+            },
+            {
+              src: 'icon-512.png',
+              sizes: '512x512',
+              type: 'image/png',
+              purpose: 'any maskable'
+            }
+          ]
+        }
+      })
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- compute the Vite base path from environment variables so GitHub Pages serves hashed assets correctly
- update the PWA manifest to reuse the computed base for start_url and scope so the service worker covers the deployed subdirectory

## Testing
- Not run (dependency installation blocked by npm registry 403 in container)


------
https://chatgpt.com/codex/tasks/task_e_68d26b603c2083249008e8b435d4dc25