### PR TITLE
Fix missing React type imports

### DIFF
--- a/src/components/auth/SignInFlow.tsx
+++ b/src/components/auth/SignInFlow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useI18n } from '@/context/I18nContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -55,7 +55,7 @@ export const SignInFlow = ({ onAuthenticated }: SignInFlowProps) => {
     }
   }, [step]);
 
-  const handleSendCode = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSendCode = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!isOnline) return;
     const trimmed = contact.trim();
@@ -75,7 +75,7 @@ export const SignInFlow = ({ onAuthenticated }: SignInFlowProps) => {
     trackEvent('auth_code_sent', { method: 'otp' });
   };
 
-  const handleVerifyCode = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleVerifyCode = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const sanitized = code.replace(/\D/g, '');
     if (sanitized.length !== 6) return;

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -114,7 +114,7 @@ type SectionProps = {
   subtitle?: string;
   items: ListingSummary[];
   isLoading: boolean;
-  renderItem: (item: ListingSummary, index: number) => React.ReactNode;
+  renderItem: (item: ListingSummary, index: number) => ReactNode;
   animationDelay: number;
 };
 
@@ -203,7 +203,7 @@ const SearchOverlay = ({
     return () => window.clearTimeout(timer);
   }, [open]);
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmed = value.trim();
     if (!trimmed) {

--- a/src/components/home/ListingCard.tsx
+++ b/src/components/home/ListingCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent, type MouseEvent } from 'react';
 import { AspectRatio } from '@/components/ui/aspect-ratio';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
@@ -152,24 +152,24 @@ export const ListingCard = ({
     onOpen(listing);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       handleOpen();
     }
   };
 
-  const handlePreOrder = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handlePreOrder = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onPreOrder(listing);
   };
 
-  const handleShare = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleShare = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onShare(listing);
   };
 
-  const handleImporterProfile = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleImporterProfile = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     navigate(`/importers/${listing.importer.id}/profile`);
   };

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { trackEvent } from '@/lib/analytics';
 
 export type Locale = 'en' | 'fr';
@@ -1730,7 +1730,7 @@ const format = (template: string, vars?: InterpolationValues) => {
   });
 };
 
-export const I18nProvider = ({ children }: { children: React.ReactNode }) => {
+export const I18nProvider = ({ children }: { children: ReactNode }) => {
   const [locale, setLocaleState] = useState<Locale>(() => getPreferredLocale());
 
   useEffect(() => {

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { Session } from '@/types';
 
 const STORAGE_KEY = 'pl.session';
@@ -12,7 +12,7 @@ type SessionContextValue = {
 
 const SessionContext = createContext<SessionContextValue | undefined>(undefined);
 
-export const SessionProvider = ({ children }: { children: React.ReactNode }) => {
+export const SessionProvider = ({ children }: { children: ReactNode }) => {
   const [session, setSessionState] = useState<Session | null>(null);
 
   useEffect(() => {

--- a/src/pages/OrderTracker.tsx
+++ b/src/pages/OrderTracker.tsx
@@ -1,5 +1,4 @@
-
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
@@ -36,7 +35,7 @@ type EvidenceKind = 'supplierInvoice' | 'awb';
 
 const milestoneOrder: MilestoneCode[] = ['POOL_LOCKED', 'SUPPLIER_PAID', 'EXPORTED', 'ARRIVED', 'COLLECTED'];
 
-const milestoneIcons: Record<MilestoneCode, React.ComponentType<{ className?: string }>> = {
+const milestoneIcons: Record<MilestoneCode, ComponentType<{ className?: string }>> = {
   POOL_LOCKED: ShieldCheck,
   SUPPLIER_PAID: BadgeCheck,
   EXPORTED: Plane,

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ComponentType, type ReactNode, type SVGProps } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   demoBuyerProfile,
@@ -124,7 +124,7 @@ const InfoRow = ({
   actionLabel,
 }: {
   label: string;
-  value: React.ReactNode;
+  value: ReactNode;
   hint?: string;
   onClick?: () => void;
   actionLabel?: string;
@@ -170,7 +170,7 @@ const QuickActionButton = ({
 }: {
   label: string;
   description: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   onClick?: () => void;
   muted?: boolean;
   badge?: string | null;


### PR DESCRIPTION
## Summary
- update the session and i18n context providers to accept `ReactNode` via typed imports instead of relying on the global React namespace
- import React form event and mouse/keyboard event types directly in interactive components like the home feed, listing card, and sign-in flow
- ensure page modules such as the order tracker and profile pages import `ComponentType`/`SVGProps` helpers explicitly to avoid implicit React references

## Testing
- npm install *(fails with 403 Forbidden when fetching ajv from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d27f0b4d68832499f514289b7337db