### PR TITLE
Simulate demo payment success flow

### DIFF
--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -605,6 +605,7 @@ const translations = {
       orderError: 'Unable to create the order. Please try again.',
       emptyPickup: 'No pickup hubs available yet.',
       processing: 'Processing payment…',
+      paymentSuccessToast: 'Payment confirmed — escrow held.',
       retry: 'Retry payment',
       statusBanner: {
         failed: 'Payment failed. No charge was made.',
@@ -1447,6 +1448,7 @@ const translations = {
       orderError: 'Impossible de créer la commande. Réessayez.',
       emptyPickup: 'Aucun hub de retrait disponible pour le moment.',
       processing: 'Traitement du paiement…',
+      paymentSuccessToast: 'Paiement confirmé — séquestre sécurisé.',
       retry: 'Réessayer le paiement',
       statusBanner: {
         failed: 'Paiement refusé. Aucun débit effectué.',

--- a/src/lib/demoOrderStorage.ts
+++ b/src/lib/demoOrderStorage.ts
@@ -1,0 +1,74 @@
+import type { OrderDetailResponse } from '@/types';
+
+export type DemoOrderRecord = OrderDetailResponse & {
+  listingId: string;
+  pickupPointId?: string | null;
+  createdAt: string;
+};
+
+type DemoOrderState = { orders: Record<string, DemoOrderRecord>; activeOrderId?: string };
+
+const STORAGE_KEY = 'pl.demo.orders';
+
+const emptyState = (): DemoOrderState => ({
+  orders: {},
+});
+
+const parseState = (value: string | null): DemoOrderState => {
+  if (!value) return emptyState();
+  try {
+    const parsed = JSON.parse(value) as {
+      orders?: Record<string, DemoOrderRecord>;
+      activeOrderId?: string;
+    };
+    if (!parsed || typeof parsed !== 'object') return emptyState();
+    return {
+      orders: parsed.orders && typeof parsed.orders === 'object' ? parsed.orders : {},
+      activeOrderId: parsed.activeOrderId,
+    };
+  } catch (error) {
+    console.warn('Failed to parse stored demo orders', error);
+    return emptyState();
+  }
+};
+
+const readState = (): DemoOrderState => {
+  if (typeof window === 'undefined') return emptyState();
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return parseState(raw);
+};
+
+const writeState = (state: DemoOrderState) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
+
+export const saveDemoOrder = (order: DemoOrderRecord) => {
+  if (typeof window === 'undefined') return;
+  const state = readState();
+  state.orders[order.id] = order;
+  state.activeOrderId = order.id;
+  writeState(state);
+};
+
+export const getDemoOrder = (id: string): DemoOrderRecord | null => {
+  if (typeof window === 'undefined') return null;
+  const state = readState();
+  const stored = state.orders[id];
+  if (!stored) return null;
+  const deadline = new Date(stored.countdown.deadline).getTime();
+  const secondsLeft = Math.max(0, Math.floor((deadline - Date.now()) / 1000));
+  return {
+    ...stored,
+    countdown: {
+      ...stored.countdown,
+      secondsLeft,
+    },
+  };
+};
+
+export const getLastDemoOrderId = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  const state = readState();
+  return state.activeOrderId ?? null;
+};


### PR DESCRIPTION
## Summary
- Simulate the Pay Now action as a client-only happy path that delays briefly, shows a success toast, stores a demo order, and navigates to tracking while firing analytics events.
- Persist demo orders in local storage so the generated order survives refreshes and can be rehydrated later.
- Hydrate the order tracker from stored demo data before falling back to the API and add copy for the payment confirmation toast.

## Testing
- npm run lint *(fails: dependencies unavailable in the container due to npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e5c303c483249c49c1e603318ffd