### PR TITLE
Revamp UI with teal-blue gradient brand aesthetic

### DIFF
--- a/src/components/auth/SignInFlow.tsx
+++ b/src/components/auth/SignInFlow.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { useI18n } from '@/context/I18nContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -123,101 +125,119 @@ export const SignInFlow = ({ onAuthenticated }: SignInFlowProps) => {
   };
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col gap-6 px-6 py-10">
-        {!isOnline && (
-          <div className="rounded-2xl border border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm">
-            {t('auth.offlineBanner')}
+    <main className="relative min-h-dvh overflow-hidden text-foreground">
+      <div className="pointer-events-none absolute inset-0 bg-app-gradient" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-white/80 via-white/40 to-transparent" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-72 bg-gradient-to-t from-white/80 via-white/30 to-transparent" />
+      <div className="relative z-10 mx-auto flex min-h-dvh w-full max-w-md flex-col items-center justify-center px-6 py-12">
+        <div className="glass-card w-full space-y-6 px-6 py-8">
+          {!isOnline && (
+            <div className="pill bg-amber-100/80 text-amber-700 shadow-soft normal-case">
+              {t('auth.offlineBanner')}
+            </div>
+          )}
+
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="flex h-14 w-14 items-center justify-center rounded-3xl bg-gradient-to-br from-primary via-teal to-blue text-primary-foreground shadow-glow">
+              <Sparkles className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
+              <h1 className="text-3xl font-semibold tracking-tight">{t('auth.welcome')}</h1>
+              <p className="mt-2 text-sm text-muted-foreground">{t('auth.intro')}</p>
+            </div>
           </div>
-        )}
 
-        <AuthStepIndicator current={step === 'otp' ? 'otp' : 'contact'} />
+          <AuthStepIndicator current={step === 'otp' ? 'otp' : 'contact'} />
 
-        <header className="space-y-2 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">{t('auth.welcome')}</h1>
-          <p className="text-muted-foreground">{t('auth.intro')}</p>
-        </header>
+          {step === 'contact' && (
+            <form className="space-y-5" onSubmit={handleSendCode}>
+              <div className="space-y-2">
+                <Label htmlFor="contact" className="text-sm font-semibold text-muted-foreground">
+                  {t('auth.contactLabel')}
+                </Label>
+                <Input
+                  id="contact"
+                  type="text"
+                  inputMode="text"
+                  value={contact}
+                  onChange={event => setContact(event.target.value)}
+                  placeholder={t('auth.contactPlaceholder')}
+                  className="h-12 rounded-2xl border border-white/60 bg-white/80 text-base shadow-sm backdrop-blur focus:border-primary/50 focus:ring-primary/40"
+                  autoComplete="email"
+                  autoFocus
+                />
+                {contactError && <p className="text-sm text-destructive">{contactError}</p>}
+              </div>
 
-        {step === 'contact' && (
-          <form className="space-y-4" onSubmit={handleSendCode}>
-            <div className="space-y-2">
-              <Label htmlFor="contact" className="text-base font-medium">
-                {t('auth.contactLabel')}
-              </Label>
-              <Input
-                id="contact"
-                type="text"
-                inputMode="text"
-                value={contact}
-                onChange={event => setContact(event.target.value)}
-                placeholder={t('auth.contactPlaceholder')}
-                className="h-12 rounded-xl border-2 text-base"
-                autoComplete="email"
-                autoFocus
-              />
-              {contactError && <p className="text-sm text-destructive">{contactError}</p>}
-            </div>
-
-            <Button type="submit" disabled={!isOnline} className="h-12 rounded-xl text-base font-semibold">
-              {t('auth.sendCode')}
-            </Button>
-            {!isOnline && <p className="text-sm text-muted-foreground">{t('auth.sendDisabled')}</p>}
-          </form>
-        )}
-
-        {step === 'otp' && (
-          <form className="space-y-6" onSubmit={handleVerifyCode}>
-            <div className="space-y-2 text-center">
-              <h2 className="text-xl font-semibold tracking-tight">{t('auth.otpTitle')}</h2>
-              <p className="text-sm text-muted-foreground">
-                {t('auth.otpSubtitle', { contact: contact.trim() })}
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <Label className="text-sm font-medium text-muted-foreground">{t('auth.codeLabel')}</Label>
-              <InputOTP
-                maxLength={6}
-                value={code}
-                onChange={value => setCode(value.replace(/\D/g, ''))}
-                containerClassName="justify-center"
-              >
-                <InputOTPGroup className="gap-2">
-                  {Array.from({ length: 6 }).map((_, index) => (
-                    <InputOTPSlot
-                      key={`otp-${index}`}
-                      index={index}
-                      className="h-12 w-12 rounded-xl border-2 text-lg font-semibold"
-                    />
-                  ))}
-                </InputOTPGroup>
-              </InputOTP>
-              {codeError && <p className="text-sm text-destructive">{codeError}</p>}
-            </div>
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={code.replace(/\D/g, '').length !== 6} className="h-12 rounded-xl text-base font-semibold">
-                {t('auth.verifyCta')}
+              <Button type="submit" disabled={!isOnline} className="h-12 w-full rounded-full text-base font-semibold">
+                {t('auth.sendCode')}
               </Button>
-              <button
-                type="button"
-                onClick={canResend ? handleResend : undefined}
-                className="text-sm font-medium text-primary"
-                disabled={!canResend}
-              >
-                {canResend ? t('auth.resendNow') : t('auth.resendIn', { time: formatTime(timeLeft) })}
-              </button>
-              <button type="button" onClick={() => setStep('contact')} className="text-sm text-muted-foreground">
-                {t('auth.changeContact')}
-              </button>
-            </div>
-          </form>
-        )}
+              {!isOnline && <p className="text-sm text-muted-foreground">{t('auth.sendDisabled')}</p>}
+            </form>
+          )}
 
-        <div className="pt-8 text-center">
-          <button type="button" onClick={handleDemo} className="text-sm font-medium text-primary">
-            {t('auth.useDemo')}
-          </button>
+          {step === 'otp' && (
+            <form className="space-y-6" onSubmit={handleVerifyCode}>
+              <div className="space-y-2 text-center">
+                <h2 className="text-2xl font-semibold tracking-tight">{t('auth.otpTitle')}</h2>
+                <p className="text-sm text-muted-foreground">
+                  {t('auth.otpSubtitle', { contact: contact.trim() })}
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <Label className="text-sm font-medium text-muted-foreground">{t('auth.codeLabel')}</Label>
+                <InputOTP
+                  maxLength={6}
+                  value={code}
+                  onChange={value => setCode(value.replace(/\D/g, ''))}
+                  containerClassName="justify-center"
+                >
+                  <InputOTPGroup className="gap-2">
+                    {Array.from({ length: 6 }).map((_, index) => (
+                      <InputOTPSlot
+                        key={`otp-${index}`}
+                        index={index}
+                        className="h-12 w-12 rounded-2xl border border-white/60 bg-white/80 text-lg font-semibold shadow-sm backdrop-blur focus:border-primary/60 focus:ring-primary/40"
+                      />
+                    ))}
+                  </InputOTPGroup>
+                </InputOTP>
+                {codeError && <p className="text-sm text-destructive">{codeError}</p>}
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <Button type="submit" disabled={code.replace(/\D/g, '').length !== 6} className="h-12 rounded-full text-base font-semibold">
+                  {t('auth.verifyCta')}
+                </Button>
+                <button
+                  type="button"
+                  onClick={canResend ? handleResend : undefined}
+                  className={cn(
+                    'text-sm font-semibold transition-colors',
+                    canResend ? 'text-primary hover:text-teal' : 'text-muted-foreground',
+                  )}
+                  disabled={!canResend}
+                >
+                  {canResend ? t('auth.resendNow') : t('auth.resendIn', { time: formatTime(timeLeft) })}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setStep('contact')}
+                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+                >
+                  {t('auth.changeContact')}
+                </button>
+              </div>
+            </form>
+          )}
+
+          <div className="pt-4 text-center">
+            <button type="button" onClick={handleDemo} className="text-sm font-semibold text-primary transition-colors hover:text-teal">
+              {t('auth.useDemo')}
+            </button>
+          </div>
         </div>
       </div>
     </main>

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -908,183 +908,192 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
   const hasResults = filteredListings.length > 0;
 
   return (
-    <div className="flex min-h-dvh flex-col bg-background" ref={containerRef}>
-      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/95 px-6 py-3 backdrop-blur">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-soft">
-              <Sparkles className="h-4 w-4" />
+    <div className="relative min-h-dvh overflow-hidden" ref={containerRef}>
+      <div className="pointer-events-none absolute inset-0 bg-app-gradient" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-60 bg-gradient-to-b from-white/70 via-white/40 to-transparent" />
+      <div className="relative z-10 flex min-h-dvh flex-col">
+        <header className="sticky top-0 z-40 px-4 pt-6 pb-4 backdrop-blur-sm">
+          <div className="space-y-3">
+            <div className="glass-card flex items-center justify-between gap-4 px-5 py-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-teal to-blue text-primary-foreground shadow-glow">
+                  <Sparkles className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
+                  <h1 className="text-2xl font-semibold tracking-tight text-foreground">{t('app.name')}</h1>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <LanguageToggle className="hidden rounded-2xl border border-white/40 bg-white/70 px-3 py-2 text-sm font-semibold text-muted-foreground shadow-sm backdrop-blur transition-colors hover:border-primary/40 hover:text-primary sm:flex" />
+                <AccountSheet session={session} />
+              </div>
             </div>
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-wide text-primary/80">{t('app.tagline')}</p>
-              <h1 className="text-lg font-semibold tracking-tight text-foreground">{t('app.name')}</h1>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <LanguageToggle className="justify-center" />
-            <AccountSheet session={session} />
-          </div>
-        </div>
-        <div className="mt-3 space-y-2">
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => {
-                setSearchDraft(searchTerm);
-                setSearchOpen(true);
-                trackEvent('search_open');
-              }}
-              className="flex h-11 flex-1 items-center gap-3 rounded-full border border-border bg-card px-4 text-left text-sm text-muted-foreground shadow-soft transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-            >
-              <Search className="h-4 w-4" />
-              <span className="flex-1 truncate">
-                {searchTerm ? searchTerm : t('home.searchPlaceholder')}
-              </span>
-              {searchTerm && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 rounded-full px-3 text-xs"
-                  onClick={event => {
-                    event.stopPropagation();
-                    setSearchTerm('');
-                    setSearchDraft('');
-                  }}
-                >
-                  {t('home.clear')}
-                </Button>
-              )}
-            </button>
-            <div className="flex flex-shrink-0 items-center gap-2">
-              <Popover open={sortMenuOpen} onOpenChange={setSortMenuOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="flex-shrink-0 h-11 w-11 rounded-full border border-border bg-card text-muted-foreground shadow-soft transition-colors hover:border-primary/40 hover:text-primary"
-                    aria-label={t('home.sortMenu')}
-                    aria-expanded={sortMenuOpen}
-                  >
-                    <ListFilter className="h-4 w-4" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-56 rounded-3xl border border-border bg-card p-3 shadow-soft">
-                  <div className="space-y-2">
-                    <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      {t('home.sortMenu')}
-                    </p>
-                    <div className="flex flex-col gap-2">
-                      {(Object.keys(sortLabels) as SortOption[]).map(option => (
-                        <button
-                          key={option}
-                          type="button"
-                          onClick={() => {
-                            handleSortChange(option);
-                            setSortMenuOpen(false);
-                          }}
-                          className={cn(
-                            'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
-                            option === sort
-                              ? 'border-primary bg-primary text-primary-foreground shadow-sm'
-                              : 'border-border bg-card text-muted-foreground hover:border-primary/40',
-                          )}
-                          aria-pressed={option === sort}
-                        >
-                          <span className="truncate">{sortLabels[option]}</span>
-                          {option === sort && <Check className="h-4 w-4" />}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </PopoverContent>
-              </Popover>
-              <Popover open={categoryMenuOpen} onOpenChange={setCategoryMenuOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="flex-shrink-0 h-11 w-11 rounded-full border border-border bg-card text-muted-foreground shadow-soft transition-colors hover:border-primary/40 hover:text-primary"
-                    aria-label={t('home.categoriesMenu')}
-                    aria-expanded={categoryMenuOpen}
-                  >
-                    <Grid2X2 className="h-4 w-4" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-64 rounded-3xl border border-border bg-card p-3 shadow-soft">
-                  <div className="space-y-2">
-                    <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      {t('home.categoriesMenu')}
-                    </p>
-                    <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
-                      {categories.map(category => (
-                        <button
-                          key={category}
-                          type="button"
-                          onClick={() => {
-                            setSelectedCategory(category);
-                            trackEvent('category_chip_click', { category });
-                            setCategoryMenuOpen(false);
-                          }}
-                          className={cn(
-                            'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
-                            selectedCategory === category
-                              ? 'border-primary bg-primary text-primary-foreground shadow-sm'
-                              : 'border-border bg-card text-muted-foreground hover:border-primary/40',
-                          )}
-                          aria-pressed={selectedCategory === category}
-                        >
-                          <span className="truncate">
-                            {category === ALL_CATEGORY ? t('home.categoriesAll') : category}
-                          </span>
-                          {selectedCategory === category && <Check className="h-4 w-4" />}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </PopoverContent>
-              </Popover>
-              <Button
-                variant="outline"
-                className={cn(
-                  'flex-shrink-0 h-11 rounded-full px-4 text-sm font-semibold shadow-soft transition-colors',
-                  activeFilterCount > 0 ? 'border-primary bg-primary/10 text-primary' : '',
-                )}
-                onClick={() => handleFilterOpen(true)}
-              >
-                <Filter className="h-4 w-4" />
-                <span>{filterLabel}</span>
-              </Button>
-            </div>
-          </div>
-          {filterPills.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {filterPills.map(pill => (
+
+            <div className="glass-card flex flex-col gap-3 px-5 py-4">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                 <button
-                  key={pill.key}
                   type="button"
-                  onClick={pill.onRemove}
-                  className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-card px-3 py-1 text-[11px] font-semibold text-muted-foreground shadow-sm transition-colors hover:border-primary/40 hover:text-primary"
-                  aria-label={t('home.removeFilter', { label: pill.label })}
+                  onClick={() => {
+                    setSearchDraft(searchTerm);
+                    setSearchOpen(true);
+                    trackEvent('search_open');
+                  }}
+                  className="group flex h-12 flex-1 items-center gap-3 rounded-full border border-white/50 bg-white/75 px-4 text-left text-sm text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                 >
-                  <span className="truncate">{pill.label}</span>
-                  <X className="h-3 w-3" />
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 via-teal/15 to-blue/20 text-primary shadow-inner">
+                    <Search className="h-4 w-4" />
+                  </span>
+                  <span className="flex-1 truncate font-medium text-foreground/70 group-hover:text-foreground">
+                    {searchTerm ? searchTerm : t('home.searchPlaceholder')}
+                  </span>
+                  {searchTerm && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 rounded-full px-4 text-xs font-semibold"
+                      onClick={event => {
+                        event.stopPropagation();
+                        setSearchTerm('');
+                        setSearchDraft('');
+                      }}
+                    >
+                      {t('home.clear')}
+                    </Button>
+                  )}
                 </button>
-              ))}
+                <div className="flex flex-shrink-0 items-center gap-2">
+                  <Popover open={sortMenuOpen} onOpenChange={setSortMenuOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/50 bg-white/80 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
+                        aria-label={t('home.sortMenu')}
+                        aria-expanded={sortMenuOpen}
+                      >
+                        <ListFilter className="h-4 w-4" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-56 rounded-3xl border border-white/50 bg-white/80 p-3 shadow-soft backdrop-blur">
+                      <div className="space-y-2">
+                        <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {t('home.sortMenu')}
+                        </p>
+                        <div className="flex flex-col gap-2">
+                          {(Object.keys(sortLabels) as SortOption[]).map(option => (
+                            <button
+                              key={option}
+                              type="button"
+                              onClick={() => {
+                                handleSortChange(option);
+                                setSortMenuOpen(false);
+                              }}
+                              className={cn(
+                                'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
+                                option === sort
+                                  ? 'border-primary bg-primary text-primary-foreground shadow-soft'
+                                  : 'border-white/40 bg-white/70 text-muted-foreground hover:border-primary/40',
+                              )}
+                              aria-pressed={option === sort}
+                            >
+                              <span className="truncate">{sortLabels[option]}</span>
+                              {option === sort && <Check className="h-4 w-4" />}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                  <Popover open={categoryMenuOpen} onOpenChange={setCategoryMenuOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/50 bg-white/80 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
+                        aria-label={t('home.categoriesMenu')}
+                        aria-expanded={categoryMenuOpen}
+                      >
+                        <Grid2X2 className="h-4 w-4" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-64 rounded-3xl border border-white/50 bg-white/80 p-3 shadow-soft backdrop-blur">
+                      <div className="space-y-2">
+                        <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {t('home.categoriesMenu')}
+                        </p>
+                        <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                          {categories.map(category => (
+                            <button
+                              key={category}
+                              type="button"
+                              onClick={() => {
+                                setSelectedCategory(category);
+                                trackEvent('category_chip_click', { category });
+                                setCategoryMenuOpen(false);
+                              }}
+                              className={cn(
+                                'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
+                                selectedCategory === category
+                                  ? 'border-primary bg-primary text-primary-foreground shadow-soft'
+                                  : 'border-white/40 bg-white/70 text-muted-foreground hover:border-primary/40',
+                              )}
+                              aria-pressed={selectedCategory === category}
+                            >
+                              <span className="truncate">
+                                {category === ALL_CATEGORY ? t('home.categoriesAll') : category}
+                              </span>
+                              {selectedCategory === category && <Check className="h-4 w-4" />}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                  <Button
+                    variant="outline"
+                    className={cn(
+                      'flex h-12 items-center gap-2 rounded-full border border-white/50 bg-white/80 px-5 text-sm font-semibold shadow-soft transition-all hover:border-primary/40 hover:text-primary',
+                      activeFilterCount > 0 ? 'border-primary bg-primary/15 text-primary' : '',
+                    )}
+                    onClick={() => handleFilterOpen(true)}
+                  >
+                    <Filter className="h-4 w-4" />
+                    <span>{filterLabel}</span>
+                  </Button>
+                </div>
+              </div>
+              {filterPills.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {filterPills.map(pill => (
+                    <button
+                      key={pill.key}
+                      type="button"
+                      onClick={pill.onRemove}
+                      className="pill bg-white/70 text-muted-foreground hover:border-primary/40 hover:text-primary"
+                      aria-label={t('home.removeFilter', { label: pill.label })}
+                    >
+                      <span className="truncate">{pill.label}</span>
+                      <X className="h-3 w-3" />
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      </header>
+          </div>
+        </header>
 
-      <div className="px-6 pt-4 pb-2">
-        <div className="inline-flex items-center rounded-full border border-border/70 bg-card px-4 py-1.5 text-sm text-muted-foreground shadow-soft">
-          <span>{t('home.heroCopy')}</span>
+        <div className="px-5 pb-4">
+          <div className="pill gap-2 bg-white/75 text-muted-foreground shadow-soft">
+            <Sparkles className="h-4 w-4 text-primary" />
+            <span className="text-[12px] font-medium normal-case tracking-normal">{t('home.heroCopy')}</span>
+          </div>
         </div>
-      </div>
 
-      <SearchOverlay
+        <SearchOverlay
         open={searchOpen}
         value={searchDraft}
         onClose={() => {
@@ -1353,7 +1362,7 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
                   key={item.id}
                   listing={item}
                   position={index}
-              formattedPrice={formatPrice(item.priceXAF)}
+                  formattedPrice={formatPrice(item.priceXAF)}
                   lockCountdown={formatLockCountdown(item.moq.lockAt)}
                   onOpen={listing => handleCardOpen(listing, index)}
                   onPreOrder={handlePreOrder}
@@ -1376,5 +1385,7 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
         </div>
       </main>
     </div>
-  );
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-white/70 via-white/30 to-transparent" />
+  </div>
+);
 };

--- a/src/components/home/ListingCard.tsx
+++ b/src/components/home/ListingCard.tsx
@@ -21,15 +21,15 @@ import { useNavigate } from 'react-router-dom';
 
 const laneBadgeStyles = {
   green: {
-    base: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    base: 'border border-primary/40 bg-primary/15 text-primary shadow-soft',
     icon: CheckCircle2,
   },
   amber: {
-    base: 'bg-amber-50 text-amber-700 border-amber-200',
+    base: 'border border-amber-300/50 bg-amber-100/40 text-amber-700 shadow-soft',
     icon: AlertTriangle,
   },
   red: {
-    base: 'bg-rose-50 text-rose-700 border-rose-200',
+    base: 'border border-rose-300/50 bg-rose-100/40 text-rose-600 shadow-soft',
     icon: XCircle,
   },
 } as const;
@@ -182,7 +182,7 @@ export const ListingCard = ({
       aria-label={cardAria}
       onKeyDown={handleKeyDown}
       onClick={handleOpen}
-      className="group relative flex cursor-pointer flex-col gap-5 rounded-3xl border border-border/70 bg-card p-5 shadow-soft transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 active:translate-y-[1px]"
+      className="group relative flex cursor-pointer flex-col gap-5 overflow-hidden rounded-3xl border border-white/50 bg-white/75 p-5 shadow-soft backdrop-blur transition-all duration-200 hover:-translate-y-1 hover:shadow-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 active:translate-y-[1px] before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:bg-gradient-to-br before:from-blue/20 before:via-transparent before:to-primary/20 before:opacity-0 before:transition-opacity before:content-[''] group-hover:before:opacity-100"
     >
       <div className="relative">
         <AspectRatio ratio={4 / 3} className="overflow-hidden rounded-2xl bg-muted">
@@ -210,16 +210,16 @@ export const ListingCard = ({
         <div className="absolute left-4 top-4 flex items-center gap-2">
           <span
             aria-label={etaChipAria}
-            className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/90 px-3 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur"
+            className="pill gap-1.5 bg-white/85 text-foreground/80 shadow-soft normal-case"
           >
-            <Clock3 className="h-3.5 w-3.5" />
+            <Clock3 className="h-3.5 w-3.5 text-blue" />
             {etaChipLabel}
           </span>
         </div>
         <div className="absolute right-4 top-4">
           <span
             className={cn(
-              'inline-flex max-w-[220px] items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium shadow-sm backdrop-blur',
+              'pill max-w-[220px] gap-1.5 bg-white/80 text-foreground/80 normal-case',
               laneBadgeStyles[tone].base,
             )}
             aria-label={`${laneLabel}`}
@@ -238,7 +238,7 @@ export const ListingCard = ({
                 {listing.title}
               </h3>
               {listing.importer.verified && (
-                <span className="flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                <span className="pill gap-1.5 border-primary/40 bg-primary/15 text-primary normal-case">
                   <CheckCheck className="h-3.5 w-3.5" />
                   {t('home.verifiedImporter')}
                 </span>
@@ -248,7 +248,7 @@ export const ListingCard = ({
               <button
                 type="button"
                 onClick={handleImporterProfile}
-                className="inline-flex items-center gap-1 rounded-full bg-muted/70 px-3 py-1 text-xs font-semibold text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                className="inline-flex items-center gap-1 rounded-full border border-white/60 bg-white/80 px-3 py-1 text-xs font-semibold text-muted-foreground shadow-sm transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               >
                 <span className="truncate">
                   {t('home.importerByline', { name: listing.importer.displayName })}
@@ -263,20 +263,22 @@ export const ListingCard = ({
           </div>
         </div>
 
-        <p className="text-sm text-muted-foreground">{factsLine}</p>
+        <p className="text-sm text-muted-foreground/90">{factsLine}</p>
 
         <div className="flex items-center gap-3">
-          <Progress value={progressValue} aria-label={progressAria} className="h-2.5 flex-1 rounded-full bg-muted" />
+          <Progress value={progressValue} aria-label={progressAria} className="flex-1" />
           {percent >= 80 && (
-            <span className="rounded-full bg-emerald-100 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-700">
+            <span className="pill gap-1 border-primary/40 bg-primary/20 text-primary">
               {t('home.almostThere')}
             </span>
           )}
         </div>
 
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <ShieldCheck className="h-4 w-4 text-emerald-600" />
-          <span>{t('home.heroCopy')}</span>
+        <div className="flex items-center gap-3 text-sm text-muted-foreground/90">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary shadow-inner">
+            <ShieldCheck className="h-4 w-4" />
+          </span>
+          <span className="font-medium text-foreground/80">{t('home.heroCopy')}</span>
         </div>
       </div>
 
@@ -284,7 +286,7 @@ export const ListingCard = ({
         <Button
           onClick={handlePreOrder}
           aria-label={`${t('home.preorder')} ${listing.title}`}
-          className="h-12 flex-1 rounded-full text-base font-semibold shadow-soft"
+          className="h-12 flex-1 rounded-full text-base font-semibold shadow-lux"
         >
           {t('home.preorder')}
         </Button>
@@ -295,7 +297,7 @@ export const ListingCard = ({
               variant="outline"
               onClick={handleShare}
               aria-label={t('home.shareWhatsapp', { title: listing.title })}
-              className="h-12 w-12 rounded-full border border-border bg-card p-0 text-foreground shadow-sm"
+              className="h-12 w-12 rounded-full border border-white/60 bg-white/80 p-0 text-muted-foreground shadow-soft backdrop-blur hover:border-primary/40 hover:text-primary"
             >
               <MessageCircle className="h-5 w-5" />
             </Button>

--- a/src/components/importer/ImporterDashboard.tsx
+++ b/src/components/importer/ImporterDashboard.tsx
@@ -93,26 +93,26 @@ const buyerNames = ['Fabrice N.', 'Stéphanie K.', 'Roland T.', 'Claudia M.', 'Y
 function getLaneTone(signal: ImporterListing['lane']['signal']) {
   switch (signal) {
     case 'green':
-      return 'bg-emerald-500/15 text-emerald-600 border-emerald-500/40';
+      return 'border border-primary/40 bg-primary/15 text-primary shadow-soft';
     case 'amber':
-      return 'bg-amber-500/15 text-amber-600 border-amber-500/30';
+      return 'border border-amber-300/50 bg-amber-100/40 text-amber-700 shadow-soft';
     case 'red':
-      return 'bg-red-500/15 text-red-600 border-red-500/30';
+      return 'border border-rose-300/50 bg-rose-100/40 text-rose-600 shadow-soft';
     default:
-      return 'bg-muted text-muted-foreground border-border';
+      return 'border border-white/50 bg-white/70 text-muted-foreground shadow-sm';
   }
 }
 
 function getStatusChipTone(status: ReturnType<typeof statusTone>) {
   switch (status) {
     case 'green':
-      return 'bg-emerald-500/15 text-emerald-600 border-emerald-500/30';
+      return 'border border-primary/40 bg-primary/15 text-primary shadow-soft';
     case 'amber':
-      return 'bg-amber-500/20 text-amber-700 border-amber-500/30';
+      return 'border border-amber-300/50 bg-amber-100/40 text-amber-700 shadow-soft';
     case 'blue':
-      return 'bg-sky-500/15 text-sky-600 border-sky-500/30';
+      return 'border border-blue/40 bg-blue/15 text-blue shadow-soft';
     default:
-      return 'bg-slate-500/15 text-slate-600 border-slate-400/30';
+      return 'border border-white/50 bg-white/70 text-muted-foreground shadow-sm';
   }
 }
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,22 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-semibold tracking-tight ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-gradient-to-r from-primary via-teal to-blue text-primary-foreground shadow-glow hover:shadow-lux hover:brightness-105 active:scale-[0.98]",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        outline:
+          "border border-white/50 bg-white/80 text-foreground shadow-sm backdrop-blur hover:border-primary/40 hover:text-primary",
+        secondary:
+          "bg-gradient-to-r from-blue to-ocean text-primary-foreground shadow-soft hover:shadow-card",
+        ghost: "hover:bg-white/40 hover:text-primary",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-11 rounded-xl px-6",
+        sm: "h-9 rounded-lg px-4 text-sm",
+        lg: "h-12 rounded-2xl px-8 text-base",
+        icon: "h-11 w-11 rounded-xl",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,11 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn("rounded-3xl border border-white/50 bg-white/80 text-card-foreground shadow-soft backdrop-blur", className)}
+    {...props}
+  />
 ));
 Card.displayName = "Card";
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -9,11 +9,14 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+    className={cn(
+      "relative h-3 w-full overflow-hidden rounded-full bg-white/50 backdrop-blur-sm shadow-inner",
+      className,
+    )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full flex-1 bg-gradient-to-r from-primary via-teal to-blue transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/index.css
+++ b/src/index.css
@@ -7,18 +7,29 @@
 @layer base {
   :root {
     /* Brand Colors */
-    --color-primary: 142 81% 40%;        /* #0FBF6D */
-    --color-timer: 142 84% 39%;          /* #0AA66D */
-    --color-teal: 180 97% 33%;           /* #03A6A6 */
-    --color-blue: 195 97% 39%;           /* #049DBF */
-    
+    --color-primary: 152 85% 40%;          /* #0FBF6D */
+    --color-timer: 158 88% 35%;            /* #0AA66D */
+    --color-teal: 180 96% 33%;             /* #03A6A6 */
+    --color-blue: 191 96% 38%;             /* #049DBF */
+    --color-ocean: 197 96% 38%;            /* #048ABF */
+
     /* Base Colors */
-    --color-fg: 0 0% 7%;                 /* #111111 */
-    --color-muted: 0 0% 47%;             /* #777777 */
-    --color-bg: 0 0% 97%;                /* #F7F7F7 */
-    --color-card: 0 0% 100%;             /* #FFFFFF */
-    --color-border: 0 0% 93%;            /* #EEEEEE */
-    
+    --color-fg: 210 27% 12%;               /* #132235 */
+    --color-muted: 210 15% 46%;            /* #6E7C8B */
+    --color-bg: 197 72% 96%;               /* #EFF7FB */
+    --color-card: 0 0% 100%;               /* #FFFFFF */
+    --color-border: 196 56% 86%;           /* #CFE8F4 */
+    --color-glass: 0 0% 100% / 0.78;
+
+    /* Decorative tokens */
+    --gradient-aurora:
+      radial-gradient(circle at 15% 15%, hsl(var(--color-blue) / 0.32), transparent 60%),
+      radial-gradient(circle at 85% 10%, hsl(var(--color-teal) / 0.28), transparent 60%),
+      radial-gradient(120% 120% at 80% 85%, hsl(var(--color-primary) / 0.25), transparent 55%);
+    --shadow-lux: 0 28px 60px -28px rgba(4, 154, 191, 0.55);
+    --shadow-glow: 0 18px 40px -16px rgba(15, 191, 109, 0.45);
+    --font-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+
     /* Semantic tokens for shadcn compatibility */
     --background: var(--color-bg);
     --foreground: var(--color-fg);
@@ -50,28 +61,36 @@ html, body {
 
 /* Component utilities */
 @layer components {
+  .glass-card {
+    @apply rounded-3xl border border-white/40 bg-white/80 shadow-lux backdrop-blur-xl;
+  }
+
+  .pill {
+    @apply inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80 shadow-sm backdrop-blur;
+  }
+
   .btn-primary {
-    @apply inline-flex items-center justify-center rounded-xl bg-primary px-4 py-3 text-white font-semibold shadow-soft active:scale-[0.99] transition-transform;
+    @apply inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-primary via-teal to-blue px-4 py-3 text-primary-foreground font-semibold shadow-glow transition-all duration-200 hover:shadow-lux active:scale-[0.98];
   }
-  
+
   .btn-outline {
-    @apply inline-flex items-center justify-center rounded-xl border border-border bg-card px-4 py-3 text-foreground font-semibold hover:bg-muted/50;
+    @apply inline-flex items-center justify-center rounded-2xl border border-white/50 bg-white/80 px-4 py-3 text-foreground font-semibold shadow-sm backdrop-blur hover:border-primary/40 hover:text-primary;
   }
-  
+
   .chip {
-    @apply inline-flex items-center gap-2 rounded-xl border px-3 py-1 text-sm font-medium;
+    @apply inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground backdrop-blur;
   }
-  
+
   .chip-escrow {
-    @apply border-primary/30 bg-primary/5 text-primary;
+    @apply border-primary/40 bg-primary/10 text-primary;
   }
-  
+
   .chip-lane {
-    @apply border-teal/30 bg-teal/5 text-teal;
+    @apply border-blue/40 bg-blue/10 text-blue;
   }
-  
+
   .chip-timer {
-    @apply border-timer/30 bg-timer/5 text-timer;
+    @apply border-timer/40 bg-timer/10 text-timer;
   }
 }
 
@@ -92,11 +111,24 @@ html, body {
   }
 
   .shadow-soft {
-    box-shadow: 0 6px 20px rgba(0,0,0,0.06);
+    box-shadow: 0 10px 30px rgba(10, 52, 84, 0.06);
   }
-  
+
   .shadow-card {
-    box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+    box-shadow: 0 18px 45px rgba(4, 154, 191, 0.14);
+  }
+
+  .shadow-lux {
+    box-shadow: var(--shadow-lux);
+  }
+
+  .shadow-glow {
+    box-shadow: var(--shadow-glow);
+  }
+
+  .bg-app-gradient {
+    background-color: hsl(var(--color-bg));
+    background-image: var(--gradient-aurora);
   }
 }
 
@@ -106,6 +138,11 @@ html, body {
   }
 
   body {
-    @apply bg-background text-foreground;
+    font-family: var(--font-primary);
+    background-color: hsl(var(--color-bg));
+    background-image: var(--gradient-aurora);
+    background-attachment: fixed;
+    background-size: cover;
+    color: hsl(var(--color-fg));
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,6 @@ import { SignInFlow } from '@/components/auth/SignInFlow';
 import { RoleChooser } from '@/components/auth/RoleChooser';
 import { useSession } from '@/context/SessionContext';
 import { useI18n } from '@/context/I18nContext';
-import { Badge } from '@/components/ui/badge';
 import type { Session } from '@/types';
 import { HomeFeed } from '@/components/home/HomeFeed';
 import { AccountSheet, LanguageToggle, languageNames } from '@/components/shell/AccountControls';
@@ -18,30 +17,31 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
   const modeLabel = t('roles.importerBadge');
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <div className="mx-auto flex min-h-dvh w-full max-w-3xl flex-col gap-8 px-6 py-10">
-        <header className="flex flex-col gap-6">
-          <div className="flex items-center justify-between">
+    <main className="relative min-h-dvh overflow-hidden text-foreground">
+      <div className="pointer-events-none absolute inset-0 bg-app-gradient" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-white/80 via-white/40 to-transparent" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-64 bg-gradient-to-t from-white/80 via-white/30 to-transparent" />
+      <div className="relative z-10 mx-auto flex min-h-dvh w-full max-w-3xl flex-col gap-8 px-6 py-10">
+        <header className="glass-card flex flex-col gap-6 px-6 py-6 shadow-lux">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-xs font-semibold uppercase text-primary/80">{t('app.tagline')}</p>
-              <h1 className="text-3xl font-bold tracking-tight text-foreground">{t('app.name')}</h1>
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
+              <h1 className="text-4xl font-semibold tracking-tight text-foreground">{t('app.name')}</h1>
             </div>
             <div className="flex items-center gap-3">
-              <LanguageToggle />
+              <LanguageToggle className="rounded-2xl border border-white/40 bg-white/70 px-3 py-2 text-sm font-semibold text-muted-foreground shadow-sm backdrop-blur transition-colors hover:border-primary/40 hover:text-primary" />
               <AccountSheet session={session} />
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <Badge variant="outline" className="rounded-full border-primary/60 bg-primary/10 px-3 py-1 text-primary">
-              {modeLabel}
-            </Badge>
-            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {languageNames[locale]}
-            </span>
+            <span className="pill bg-primary/20 text-primary normal-case">{modeLabel}</span>
+            <span className="pill bg-white/75 text-muted-foreground/80 normal-case">{languageNames[locale]}</span>
           </div>
         </header>
 
-        <ImporterDashboard session={session} />
+        <div className="glass-card px-4 py-6 shadow-soft">
+          <ImporterDashboard session={session} />
+        </div>
       </div>
     </main>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,7 +23,8 @@ export default {
         timer: "hsl(var(--color-timer))",
         teal: "hsl(var(--color-teal))",
         blue: "hsl(var(--color-blue))",
-        
+        ocean: "hsl(var(--color-ocean))",
+
         /* Base colors */
         fg: "hsl(var(--color-fg))",
         bg: "hsl(var(--color-bg))",


### PR DESCRIPTION
## Summary
- refresh the global design tokens to use the provided teal and aqua palette with aurora gradients, glass surfaces, and premium shadow utilities
- restyle key surfaces (home feed, listing cards, sign-in flow, importer shell) with gradient headers, glass cards, and bold typography reminiscent of leading social apps
- modernize shared UI elements like buttons, progress bars, and cards while aligning importer dashboard badges with the new color system

## Testing
- `npm run build` *(fails: vite not found because dependencies are unavailable prior to installation)*
- `npm install` *(fails: registry returned 403, preventing dependency installation in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2feb8363c8324919b982e39781f18