### PR TITLE
Replace placeholder logo with uploaded asset

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,20 @@
+import type { ImgHTMLAttributes } from 'react';
+import { useI18n } from '@/context/I18nContext';
+import { cn } from '@/lib/utils';
+
+export type LogoProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'>;
+
+export const Logo = ({ className, alt, ...props }: LogoProps) => {
+  const { t } = useI18n();
+
+  return (
+    <img
+      src="/images/logo.png"
+      alt={alt ?? t('app.name')}
+      className={cn('h-10 w-auto', className)}
+      {...props}
+    />
+  );
+};
+
+export default Logo;

--- a/src/components/auth/SignInFlow.tsx
+++ b/src/components/auth/SignInFlow.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
-import { Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/context/I18nContext';
 import { Button } from '@/components/ui/button';
@@ -10,6 +9,7 @@ import { AuthStepIndicator } from './AuthStepIndicator';
 import { useNetworkStatus } from '@/hooks/use-network-status';
 import type { Session } from '@/types';
 import { trackEvent } from '@/lib/analytics';
+import { Logo } from '@/components/Logo';
 
 const OTP_CODE = '123456';
 
@@ -138,9 +138,7 @@ export const SignInFlow = ({ onAuthenticated }: SignInFlowProps) => {
           )}
 
           <div className="flex flex-col items-center gap-4 text-center">
-            <div className="flex h-14 w-14 items-center justify-center rounded-3xl bg-gradient-to-br from-primary via-teal to-blue text-primary-foreground shadow-glow">
-              <Sparkles className="h-6 w-6" />
-            </div>
+            <Logo className="h-12 w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
               <h1 className="text-3xl font-semibold tracking-tight">{t('auth.welcome')}</h1>

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -40,6 +40,7 @@ import { useIntersectionOnce } from '@/hooks/use-intersection-once';
 import { cn } from '@/lib/utils';
 import { activateDemoMode, DEMO_LISTINGS, isDemoActive } from '@/lib/demoMode';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Logo } from '@/components/Logo';
 
 const RECENT_KEY = 'pl.recentListings';
 const RECENT_SEARCH_KEY = 'pl.recentSearches';
@@ -916,9 +917,7 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
           <div className="space-y-3">
             <div className="glass-card flex items-center justify-between gap-4 px-5 py-4">
               <div className="flex items-center gap-3">
-                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-teal to-blue text-primary-foreground shadow-glow">
-                  <Sparkles className="h-5 w-5" />
-                </div>
+                <Logo className="h-9 w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
                 <div>
                   <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
                   <h1 className="text-2xl font-semibold tracking-tight text-foreground">{t('app.name')}</h1>


### PR DESCRIPTION
## Summary
- add a shared Logo component that renders the uploaded image asset
- update the sign-in flow and home feed headers to use the new logo styling

## Testing
- npm run lint *(fails: missing dependencies because npm install cannot download ajv from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d38c6300188324bbae3e9694839e10