### PR TITLE
Increase PWA cache size limit for large logo asset

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,9 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: 'autoUpdate',
         workbox: {
-          globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,avif}']
+          globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,avif}'],
+          // Allow larger static assets like the full-resolution logo to be precached.
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         },
         includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'icon-192.png', 'icon-512.png'],
         manifest: {


### PR DESCRIPTION
## Summary
- raise the Workbox `maximumFileSizeToCacheInBytes` limit to 5 MB so the newly added high-resolution logo can be precached without failing the build
- document the reason for the higher limit directly in the Vite PWA configuration

## Testing
- npm install *(fails: registry returned 403 Forbidden)*
- npm run build *(fails: vite not installed prior to dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68d3902226008324998a12ce41eec26e