### PR TITLE
Enlarge home feed header logo

### DIFF
--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -917,7 +917,7 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
           <div className="space-y-3">
             <div className="glass-card flex items-center justify-between gap-4 px-5 py-4">
               <div className="flex items-center gap-3">
-                <Logo className="h-9 w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
+                <Logo className="h-[6.75rem] w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
                 <div>
                   <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
                   <h1 className="text-2xl font-semibold tracking-tight text-foreground">{t('app.name')}</h1>


### PR DESCRIPTION
## Summary
- enlarge the home feed header logo by increasing its height to three times the previous size

## Testing
- npm run lint *(fails: missing dependencies due to npm registry access errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d392b6bce48324b8cb7820142417be