### PR TITLE
Adjust logo sizing and crop

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -4,14 +4,15 @@ import { cn } from '@/lib/utils';
 
 export type LogoProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'>;
 
-export const Logo = ({ className, alt, ...props }: LogoProps) => {
+export const Logo = ({ className, alt, style, ...props }: LogoProps) => {
   const { t } = useI18n();
 
   return (
     <img
       src="/images/logo.png"
-      alt={alt ?? t('app.name')}
-      className={cn('h-10 w-auto', className)}
+      alt={alt ?? t('app.name')} 
+      className={cn('h-12 w-auto', className)}
+      style={{ clipPath: 'inset(6%)', ...style }}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- enlarge the default logo rendering to increase its presence
- clip the logo image slightly to eliminate the thin white margin around it

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' referenced by eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d501d926488324a6b095b2bb55491c