### PR TITLE
Add install prompt button for PWA

### DIFF
--- a/src/components/pwa/InstallPwaButton.tsx
+++ b/src/components/pwa/InstallPwaButton.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Download } from 'lucide-react';
+
+import { usePwaInstall } from '@/hooks/use-pwa-install';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/context/I18nContext';
+
+type InstallPwaButtonProps = {
+  className?: string;
+};
+
+export const InstallPwaButton = ({ className }: InstallPwaButtonProps) => {
+  const { t } = useI18n();
+  const { canInstall, promptInstall } = usePwaInstall();
+  const [isPrompting, setIsPrompting] = useState(false);
+
+  if (!canInstall) {
+    return null;
+  }
+
+  const handleClick = async () => {
+    try {
+      setIsPrompting(true);
+      await promptInstall();
+    } finally {
+      setIsPrompting(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className={cn(
+        'h-9 rounded-full border-white/60 bg-white/90 px-3 text-[0.7rem] font-semibold uppercase tracking-wide text-muted-foreground shadow-soft backdrop-blur hover:border-primary/50 hover:text-primary',
+        className,
+      )}
+      onClick={handleClick}
+      disabled={isPrompting}
+    >
+      <Download className="size-3.5" aria-hidden="true" />
+      <span>{t('common.installApp')}</span>
+    </Button>
+  );
+};
+
+export default InstallPwaButton;

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -143,6 +143,7 @@ const translations = {
       language: 'Language',
       cancel: 'Cancel',
       close: 'Close',
+      installApp: 'Install app',
     },
     auth: {
       welcome: 'Welcome to ProList Mini',
@@ -1101,6 +1102,7 @@ const translations = {
       language: 'Langue',
       cancel: 'Annuler',
       close: 'Fermer',
+      installApp: "Installer l'app",
     },
     auth: {
       welcome: 'Bienvenue sur ProList Mini',

--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type BeforeInstallPromptEvent = Event & {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt: () => Promise<void>;
+};
+
+const isStandaloneDisplay = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (window.matchMedia('(display-mode: window-controls-overlay)').matches ?? false) ||
+    // @ts-expect-error - iOS Safari exposes this property on navigator
+    navigator.standalone === true
+  );
+};
+
+export const usePwaInstall = () => {
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState<boolean>(() => isStandaloneDisplay());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setPromptEvent(event as BeforeInstallPromptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      setIsInstalled(true);
+      setPromptEvent(null);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    const displayModeMedia = window.matchMedia('(display-mode: standalone)');
+    const overlayMedia = window.matchMedia('(display-mode: window-controls-overlay)');
+
+    const handleDisplayModeChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setIsInstalled(true);
+      }
+    };
+
+    if (displayModeMedia.addEventListener) {
+      displayModeMedia.addEventListener('change', handleDisplayModeChange);
+      overlayMedia.addEventListener('change', handleDisplayModeChange);
+    } else {
+      // Safari < 14
+      // eslint-disable-next-line deprecation/deprecation
+      displayModeMedia.addListener(handleDisplayModeChange);
+      // eslint-disable-next-line deprecation/deprecation
+      overlayMedia.addListener(handleDisplayModeChange);
+    }
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+
+      if (displayModeMedia.removeEventListener) {
+        displayModeMedia.removeEventListener('change', handleDisplayModeChange);
+        overlayMedia.removeEventListener('change', handleDisplayModeChange);
+      } else {
+        // eslint-disable-next-line deprecation/deprecation
+        displayModeMedia.removeListener(handleDisplayModeChange);
+        // eslint-disable-next-line deprecation/deprecation
+        overlayMedia.removeListener(handleDisplayModeChange);
+      }
+    };
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!promptEvent) {
+      return false;
+    }
+
+    await promptEvent.prompt();
+    const choice = await promptEvent.userChoice;
+    setPromptEvent(null);
+
+    if (choice.outcome === 'accepted') {
+      setIsInstalled(true);
+      return true;
+    }
+
+    return false;
+  }, [promptEvent]);
+
+  const canInstall = useMemo(() => !isInstalled && promptEvent !== null, [isInstalled, promptEvent]);
+
+  return { canInstall, promptInstall, isInstalled } as const;
+};
+
+export type UsePwaInstall = ReturnType<typeof usePwaInstall>;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import { HomeFeed } from '@/components/home/HomeFeed';
 import { AccountSheet, LanguageToggle, languageNames } from '@/components/shell/AccountControls';
 import { ImporterDashboard } from '@/components/importer/ImporterDashboard';
 import { Logo } from '@/components/Logo';
+import { InstallPwaButton } from '@/components/pwa/InstallPwaButton';
 
 const AuthenticatedShell = ({ session }: { session: Session }) => {
   const { t, locale } = useI18n();
@@ -28,7 +29,8 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
             <div className="sm:order-1">
               <AccountSheet session={session} />
             </div>
-            <div className="flex justify-end sm:order-3">
+            <div className="flex items-center justify-end gap-3 sm:order-3">
+              <InstallPwaButton className="shadow-glow sm:order-2" />
               <div className="glass-card inline-flex items-center justify-center rounded-3xl p-3 shadow-lux">
                 <Logo className="h-[4.5rem] w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
               </div>


### PR DESCRIPTION
## Summary
- add a reusable hook to manage the deferred PWA install prompt state
- surface a small install button next to the logo in the authenticated shell when install is available
- localize the install call-to-action in English and French strings

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d50496a8108324a547301a7479e215