### PR TITLE
Lighten background and reposition sorting controls

### DIFF
--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -972,97 +972,6 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
             </div>
 
             <div className="flex flex-col gap-3">
-              <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-                <Popover open={sortMenuOpen} onOpenChange={setSortMenuOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="flex h-11 w-11 items-center justify-center rounded-full border border-white/60 bg-white/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
-                      aria-label={t('home.sortMenu')}
-                      aria-expanded={sortMenuOpen}
-                    >
-                      <ListFilter className="h-4 w-4" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="start" className="w-56 rounded-3xl border border-white/50 bg-white/80 p-3 shadow-soft backdrop-blur">
-                    <div className="space-y-2">
-                      <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        {t('home.sortMenu')}
-                      </p>
-                      <div className="flex flex-col gap-2">
-                        {(Object.keys(sortLabels) as SortOption[]).map(option => (
-                          <button
-                            key={option}
-                            type="button"
-                            onClick={() => {
-                              handleSortChange(option);
-                              setSortMenuOpen(false);
-                            }}
-                            className={cn(
-                              'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
-                              option === sort
-                                ? 'border-primary bg-primary text-primary-foreground shadow-soft'
-                                : 'border-white/40 bg-white/70 text-muted-foreground hover:border-primary/40',
-                            )}
-                            aria-pressed={option === sort}
-                          >
-                            <span className="truncate">{sortLabels[option]}</span>
-                            {option === sort && <Check className="h-4 w-4" />}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-                <Popover open={categoryMenuOpen} onOpenChange={setCategoryMenuOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="flex h-11 w-11 items-center justify-center rounded-full border border-white/60 bg-white/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
-                      aria-label={t('home.categoriesMenu')}
-                      aria-expanded={categoryMenuOpen}
-                    >
-                      <Grid2X2 className="h-4 w-4" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="start" className="w-64 rounded-3xl border border-white/50 bg-white/80 p-3 shadow-soft backdrop-blur">
-                    <div className="space-y-2">
-                      <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        {t('home.categoriesMenu')}
-                      </p>
-                      <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
-                        {categories.map(category => (
-                          <button
-                            key={category}
-                            type="button"
-                            onClick={() => {
-                              setSelectedCategory(category);
-                              trackEvent('category_chip_click', { category });
-                              setCategoryMenuOpen(false);
-                            }}
-                            className={cn(
-                              'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
-                              selectedCategory === category
-                                ? 'border-primary bg-primary text-primary-foreground shadow-soft'
-                                : 'border-white/40 bg-white/70 text-muted-foreground hover:border-primary/40',
-                            )}
-                            aria-pressed={selectedCategory === category}
-                          >
-                            <span className="truncate">
-                              {category === ALL_CATEGORY ? t('home.categoriesAll') : category}
-                            </span>
-                            {selectedCategory === category && <Check className="h-4 w-4" />}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
               {filterPills.length > 0 && (
                 <div className="flex flex-wrap gap-2">
                   {filterPills.map(pill => (
@@ -1214,6 +1123,98 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
           </DrawerFooter>
         </DrawerContent>
       </Drawer>
+
+      <div className="fixed bottom-6 left-6 z-50 flex flex-col gap-3 sm:flex-row">
+        <Popover open={sortMenuOpen} onOpenChange={setSortMenuOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
+              aria-label={t('home.sortMenu')}
+              aria-expanded={sortMenuOpen}
+            >
+              <ListFilter className="h-5 w-5" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-56 rounded-3xl border border-border bg-card/95 p-3 shadow-soft backdrop-blur">
+            <div className="space-y-2">
+              <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t('home.sortMenu')}
+              </p>
+              <div className="flex flex-col gap-2">
+                {(Object.keys(sortLabels) as SortOption[]).map(option => (
+                  <button
+                    key={option}
+                    type="button"
+                    onClick={() => {
+                      handleSortChange(option);
+                      setSortMenuOpen(false);
+                    }}
+                    className={cn(
+                      'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
+                      option === sort
+                        ? 'border-primary bg-primary text-primary-foreground shadow-soft'
+                        : 'border-border bg-card text-muted-foreground hover:border-primary/40',
+                    )}
+                    aria-pressed={option === sort}
+                  >
+                    <span className="truncate">{sortLabels[option]}</span>
+                    {option === sort && <Check className="h-4 w-4" />}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+        <Popover open={categoryMenuOpen} onOpenChange={setCategoryMenuOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
+              aria-label={t('home.categoriesMenu')}
+              aria-expanded={categoryMenuOpen}
+            >
+              <Grid2X2 className="h-5 w-5" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-64 rounded-3xl border border-border bg-card/95 p-3 shadow-soft backdrop-blur">
+            <div className="space-y-2">
+              <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t('home.categoriesMenu')}
+              </p>
+              <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                {categories.map(category => (
+                  <button
+                    key={category}
+                    type="button"
+                    onClick={() => {
+                      setSelectedCategory(category);
+                      trackEvent('category_chip_click', { category });
+                      setCategoryMenuOpen(false);
+                    }}
+                    className={cn(
+                      'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
+                      selectedCategory === category
+                        ? 'border-primary bg-primary text-primary-foreground shadow-soft'
+                        : 'border-border bg-card text-muted-foreground hover:border-primary/40',
+                    )}
+                    aria-pressed={selectedCategory === category}
+                  >
+                    <span className="truncate">
+                      {category === ALL_CATEGORY ? t('home.categoriesAll') : category}
+                    </span>
+                    {selectedCategory === category && <Check className="h-4 w-4" />}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
 
       <main className="flex-1 space-y-6 px-6 pb-24 pt-6">
         {fallbackActive && (

--- a/src/index.css
+++ b/src/index.css
@@ -16,16 +16,16 @@
     /* Base Colors */
     --color-fg: 210 27% 12%;               /* #132235 */
     --color-muted: 210 15% 46%;            /* #6E7C8B */
-    --color-bg: 197 72% 96%;               /* #EFF7FB */
+    --color-bg: 210 20% 98%;               /* #F6F8FB */
     --color-card: 0 0% 100%;               /* #FFFFFF */
     --color-border: 196 56% 86%;           /* #CFE8F4 */
     --color-glass: 0 0% 100% / 0.78;
 
     /* Decorative tokens */
     --gradient-aurora:
-      radial-gradient(circle at 15% 15%, hsl(var(--color-blue) / 0.32), transparent 60%),
-      radial-gradient(circle at 85% 10%, hsl(var(--color-teal) / 0.28), transparent 60%),
-      radial-gradient(120% 120% at 80% 85%, hsl(var(--color-primary) / 0.25), transparent 55%);
+      radial-gradient(circle at 15% 15%, hsl(var(--color-blue) / 0.08), transparent 60%),
+      radial-gradient(circle at 85% 10%, hsl(var(--color-teal) / 0.06), transparent 60%),
+      radial-gradient(120% 120% at 80% 85%, hsl(var(--color-primary) / 0.05), transparent 55%);
     --shadow-lux: 0 28px 60px -28px rgba(4, 154, 191, 0.55);
     --shadow-glow: 0 18px 40px -16px rgba(15, 191, 109, 0.45);
     --font-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
@@ -128,7 +128,7 @@ html, body {
 
   .bg-app-gradient {
     background-color: hsl(var(--color-bg));
-    background-image: var(--gradient-aurora);
+    background-image: none;
   }
 }
 
@@ -140,9 +140,7 @@ html, body {
   body {
     font-family: var(--font-primary);
     background-color: hsl(var(--color-bg));
-    background-image: var(--gradient-aurora);
-    background-attachment: fixed;
-    background-size: cover;
+    background-image: none;
     color: hsl(var(--color-fg));
   }
 }


### PR DESCRIPTION
## Summary
- lighten the global background theme to a near-white tone and remove the gradient overlay
- relocate the home feed sort and category controls to a fixed bottom-left dock
- ensure the new dock preserves the existing popover interactions and styling tokens

## Testing
- `npm run build` *(fails: vite binary unavailable in environment)*
- `npm install` *(fails: registry returns 403 for required packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d513e98c508324b2c13d25f4775992