### PR TITLE
Unify account controls across preorder and auctions

### DIFF
--- a/src/components/auctions/AuctionsFeed.tsx
+++ b/src/components/auctions/AuctionsFeed.tsx
@@ -11,14 +11,23 @@ import { useI18n } from '@/context/I18nContext';
 import { AppNav } from '@/components/navigation/AppNav';
 import { AccountSheet, LanguageToggle } from '@/components/shell/AccountControls';
 
+type ExperienceMode = 'preorder' | 'auctions';
+
 type AuctionsFeedProps = {
   variant?: 'embedded' | 'page';
   session?: Session;
+  showAccountControls?: boolean;
+  experience?: ExperienceMode;
 };
 
 const PREVIEW_BADGE_VISIBLE = import.meta.env.MODE !== 'production' || import.meta.env.DEV;
 
-export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProps) => {
+export const AuctionsFeed = ({
+  variant = 'embedded',
+  session,
+  showAccountControls = false,
+  experience = 'auctions',
+}: AuctionsFeedProps) => {
   const navigate = useNavigate();
   const { t } = useI18n();
   const [selectedAuction, setSelectedAuction] = useState<AuctionListing | null>(null);
@@ -63,12 +72,21 @@ export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProp
               </div>
               <div className="ml-auto flex items-center gap-2 sm:gap-3">
                 <LanguageToggle className="h-11 rounded-full border border-border/70 bg-white px-4 text-xs font-semibold uppercase text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary" />
-                {session && <AccountSheet session={session} />}
+                {showAccountControls && session && (
+                  <AccountSheet session={session} experience={experience} />
+                )}
               </div>
             </div>
             <AppNav className="justify-start" />
           </div>
         </header>
+      )}
+
+      {variant !== 'page' && showAccountControls && session && (
+        <div className="flex items-center justify-end gap-2 px-6 pt-4">
+          <LanguageToggle className="h-10 rounded-full border border-border/70 bg-white px-3 text-xs font-semibold uppercase text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary" />
+          <AccountSheet session={session} experience={experience} />
+        </div>
       )}
 
       <div className={`mx-auto w-full ${variant === 'page' ? 'max-w-5xl px-6 pt-6' : 'px-6 py-6'}`}>

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -62,8 +62,12 @@ type Bounds = {
   price: [number, number];
 };
 
+type ExperienceMode = 'preorder' | 'auctions';
+
 type HomeFeedProps = {
   session: Session;
+  showAccountControls?: boolean;
+  experience?: ExperienceMode;
 };
 
 const ALL_CATEGORY = '__all__';
@@ -370,7 +374,7 @@ const SearchOverlay = ({
   );
 };
 
-export const HomeFeed = ({ session }: HomeFeedProps) => {
+export const HomeFeed = ({ session, showAccountControls = true, experience = 'preorder' }: HomeFeedProps) => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { t, locale } = useI18n();
@@ -970,7 +974,9 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
                   <span className="hidden sm:inline">{filterLabel}</span>
                 </Button>
                 <LanguageToggle className="h-11 rounded-full border border-border/70 bg-white px-4 text-xs font-semibold uppercase text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary" />
-                <AccountSheet session={session} />
+                {showAccountControls && (
+                  <AccountSheet session={session} experience={experience} />
+                )}
               </div>
               <button
                 type="button"

--- a/src/components/home/HomeFeedWithToggle.tsx
+++ b/src/components/home/HomeFeedWithToggle.tsx
@@ -33,11 +33,17 @@ export const HomeFeedWithToggle = ({ session }: HomeFeedWithToggleProps) => {
       </div>
 
       {currentMode === 'preorder' ? (
-        <HomeFeed session={session} />
+        <HomeFeed
+          session={session}
+          showAccountControls={session.role === 'buyer'}
+          experience="preorder"
+        />
       ) : (
         <AuctionsFeed
           session={session}
           variant={location.pathname === '/auctions' ? 'page' : 'embedded'}
+          showAccountControls={session.role === 'buyer'}
+          experience="auctions"
         />
       )}
     </div>

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -188,6 +188,7 @@ const translations = {
       installApp: 'Install app',
       preview: 'Preview',
       back: 'Back',
+      quickLinks: 'Quick links',
     },
     navigation: {
       preorder: 'Preorder',
@@ -1199,6 +1200,7 @@ const translations = {
       installApp: "Installer l'app",
       preview: 'Préversion',
       back: 'Retour',
+      quickLinks: 'Raccourcis',
     },
     navigation: {
       preorder: 'Précommande',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,10 +9,17 @@ import { ImporterDashboard } from '@/components/importer/ImporterDashboard';
 import { Logo } from '@/components/Logo';
 import { InstallPwaButton } from '@/components/pwa/InstallPwaButton';
 import { Badge } from '@/components/ui/badge';
+import { useLocation } from 'react-router-dom';
 
 const AuthenticatedShell = ({ session }: { session: Session }) => {
   const { t, locale } = useI18n();
+  const location = useLocation();
   const showPreviewBadge = import.meta.env.MODE !== 'production' || import.meta.env.DEV;
+
+  const experience =
+    location.pathname === '/auctions' || location.pathname.startsWith('/auction')
+      ? 'auctions'
+      : 'preorder';
 
   if (session.role === 'buyer') {
     return <HomeFeedWithToggle session={session} />;
@@ -28,10 +35,7 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
       <div className="relative z-10 mx-auto flex min-h-dvh w-full max-w-3xl flex-col gap-8 px-6 py-10">
         <header className="sticky top-6 z-20 flex flex-col gap-5 rounded-3xl bg-background p-6 shadow-soft">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="sm:order-1">
-              <AccountSheet session={session} />
-            </div>
-            <div className="flex items-center justify-end gap-3 sm:order-3">
+            <div className="flex items-center justify-end gap-3 sm:order-3 sm:ml-auto">
               <InstallPwaButton className="shadow-glow sm:order-2" />
               <div className="glass-card inline-flex items-center justify-center rounded-3xl p-3 shadow-lux">
                 <Logo className="h-[4.5rem] w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
@@ -41,6 +45,7 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
                   {t('common.preview')}
                 </Badge>
               )}
+              <AccountSheet session={session} experience={experience} />
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-3">

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
   type SVGProps,
 } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   demoBuyerProfile,
   demoImporterProfile,
@@ -338,6 +338,7 @@ const computeStepProgress = (steps: VerificationStep[]) => {
 
 const Profile = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { session } = useSession();
   const { t, locale } = useI18n();
 
@@ -359,6 +360,14 @@ const Profile = () => {
   const [newHub, setNewHub] = useState({ name: '', address: '', city: '', phone: '' });
   const [supportTopic, setSupportTopic] = useState<SupportTopic>('order');
   const [supportMessage, setSupportMessage] = useState('');
+
+  useEffect(() => {
+    const state = location.state as { quickFlow?: QuickFlow } | null;
+    if (state?.quickFlow) {
+      setActiveFlow(state.quickFlow);
+      navigate(location.pathname, { replace: true });
+    }
+  }, [location.pathname, location.state, navigate]);
 
   const activeBuyer = buyerProfile ?? demoBuyerProfile;
   const activeImporter = importerProfile ?? demoImporterProfile;


### PR DESCRIPTION
## Summary
- move the shared account sheet into the importer shell header so only one profile control is visible
- teach the account sheet to surface preorder or auctions quick links depending on the active tab and wire quick-flow navigation
- pass the active mode through the home and auctions feeds so buyers still see account controls and language toggles consistently

## Testing
- npm run lint *(fails: npm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d5502730d083249bdfc5bce141651b