### PR TITLE
Adjust profile actions layout and localize auction timing

### DIFF
--- a/src/components/auctions/AuctionCard.tsx
+++ b/src/components/auctions/AuctionCard.tsx
@@ -72,6 +72,7 @@ export const AuctionCard = ({ auction, onViewDetails, onViewSeller, onPlaceBid }
 
   const isEnding = timeLeft <= 3600;
   const hasEnded = timeLeft <= 0;
+  const timeRemainingLabel = hasEnded ? t('auctions.ended') : formatTimeLeft(timeLeft, locale);
   const watchersLabel = t('auctions.watchersLabel', { count: auction.watchers });
   const laneLabel = auction.lane ? t('auctions.laneOnTime', { percent: Math.round(auction.lane.onTimePct * 100) }) : null;
 
@@ -103,7 +104,7 @@ export const AuctionCard = ({ auction, onViewDetails, onViewSeller, onPlaceBid }
               )}
             >
               <Clock className="h-3 w-3" />
-              {formatTimeLeft(timeLeft)}
+              {timeRemainingLabel}
             </Badge>
           </div>
         </AspectRatio>

--- a/src/components/navigation/AppNav.tsx
+++ b/src/components/navigation/AppNav.tsx
@@ -25,14 +25,6 @@ export const AppNav = ({ className }: AppNavProps) => {
         location.pathname === '/auctions' ||
         location.pathname.startsWith('/auction'),
     },
-    {
-      key: 'profile',
-      label: t('navigation.profile'),
-      href: '/account',
-      active:
-        location.pathname.startsWith('/account') ||
-        location.pathname.startsWith('/profile'),
-    },
   ];
 
   return (

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -312,6 +312,7 @@ const translations = {
         sellerFallback: 'Seller unavailable',
         viewAuction: 'Open auction',
         viewSeller: 'View seller',
+        ended: 'Auction ended',
       },
       watchlist: {
         title: 'Watchlist',
@@ -324,6 +325,7 @@ const translations = {
         sellerFallback: 'Seller unavailable',
         viewAuction: 'Open auction',
         viewSeller: 'View seller',
+        ended: 'Auction ended',
       },
       wins: {
         title: 'Wins',
@@ -1323,6 +1325,7 @@ const translations = {
         sellerFallback: 'Vendeur indisponible',
         viewAuction: 'Ouvrir l’enchère',
         viewSeller: 'Voir le vendeur',
+        ended: 'Enchère terminée',
       },
       watchlist: {
         title: 'Suivi',
@@ -1335,6 +1338,7 @@ const translations = {
         sellerFallback: 'Vendeur indisponible',
         viewAuction: 'Ouvrir l’enchère',
         viewSeller: 'Voir le vendeur',
+        ended: 'Enchère terminée',
       },
       wins: {
         title: 'Gagnées',

--- a/src/lib/auctionData.ts
+++ b/src/lib/auctionData.ts
@@ -283,17 +283,36 @@ export const updateWinStatus = (winId: string, status: AuctionWin['status']): vo
   }
 };
 
-export const formatTimeLeft = (seconds: number): string => {
-  if (seconds <= 0) return 'Ended';
-  
+export const formatTimeLeft = (seconds: number, locale: 'en' | 'fr' = 'en'): string => {
+  if (seconds <= 0) {
+    return locale === 'fr' ? 'Terminé' : 'Ended';
+  }
+
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
-  
+  const remainingSeconds = seconds % 60;
+  const formatter = new Intl.NumberFormat(locale === 'fr' ? 'fr-FR' : 'en-US');
+
+  const suffixes = {
+    hour: locale === 'fr' ? '\u202Fh' : 'h',
+    minute: locale === 'fr' ? '\u202Fmin' : 'm',
+    second: locale === 'fr' ? '\u202Fs' : 's',
+  } as const;
+
+  const formatPart = (value: number, unit: keyof typeof suffixes) =>
+    `${formatter.format(value)}${suffixes[unit]}`;
+
   if (hours > 0) {
-    return `${hours}h ${minutes}m`;
-  } else if (minutes > 0) {
-    return `${minutes}m`;
-  } else {
-    return `${seconds}s`;
+    const parts = [formatPart(hours, 'hour')];
+    if (minutes > 0) {
+      parts.push(formatPart(minutes, 'minute'));
+    }
+    return parts.join(' ');
   }
+
+  if (minutes > 0) {
+    return formatPart(minutes, 'minute');
+  }
+
+  return formatPart(remainingSeconds, 'second');
 };

--- a/src/pages/AuctionDetail.tsx
+++ b/src/pages/AuctionDetail.tsx
@@ -144,6 +144,7 @@ const AuctionDetail = () => {
 
   const isEnding = timeLeft <= 3600; // Less than 1 hour
   const hasEnded = timeLeft <= 0;
+  const timeDisplay = hasEnded ? t('auctions.ended') : formatTimeLeft(timeLeft, locale);
   const minBid = auction.currentBidXAF + auction.minIncrementXAF;
 
   return (
@@ -192,7 +193,7 @@ const AuctionDetail = () => {
               )}
             >
               <Clock className="h-4 w-4" />
-              {formatTimeLeft(timeLeft)}
+              {timeDisplay}
             </Badge>
           </div>
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1106,22 +1106,20 @@ const Profile = () => {
           </div>
 
           {mode === 'buyer' && (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="grid w-full max-w-sm grid-cols-2 gap-2 sm:max-w-md">
               {auctionTiles.map(tile => (
                 <button
                   key={tile.key}
                   type="button"
                   onClick={tile.onClick}
-                  className="group flex flex-col gap-2 rounded-3xl border border-border/70 bg-card/90 p-4 text-left shadow-soft transition-all hover:-translate-y-0.5 hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 active:translate-y-[1px]"
+                  className="group flex flex-col gap-1.5 rounded-xl border border-border/70 bg-card/80 px-3 py-3 text-left text-xs font-medium text-muted-foreground transition-colors hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                 >
-                  <div className="flex items-center justify-between">
-                    <span className="text-3xl font-semibold text-foreground">{tile.count}</span>
-                    <ArrowRight className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-primary" />
+                  <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    <span className="truncate">{tile.label}</span>
+                    <ArrowRight className="h-3 w-3 text-muted-foreground transition-colors group-hover:text-primary" />
                   </div>
-                  <div className="space-y-1">
-                    <p className="text-sm font-semibold text-foreground">{tile.label}</p>
-                    <p className="text-xs text-muted-foreground">{tile.hint}</p>
-                  </div>
+                  <span className="text-lg font-semibold text-foreground">{tile.count}</span>
+                  <p className="text-[11px] leading-snug text-muted-foreground/90">{tile.hint}</p>
                 </button>
               ))}
             </div>

--- a/src/pages/ProfileBids.tsx
+++ b/src/pages/ProfileBids.tsx
@@ -91,6 +91,8 @@ const ProfileBids = () => {
           {bids.map(bid => {
             const auction = enrichBid(bid);
             const seller = auction?.seller;
+            const hasEnded = bid.timeLeftSec <= 0;
+            const timeRemaining = formatTimeLeft(bid.timeLeftSec, locale);
 
             return (
               <article
@@ -122,7 +124,9 @@ const ProfileBids = () => {
                     </p>
                     <p className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground">
                       <Clock className="h-3.5 w-3.5" />
-                      {t('profile.bids.timeLeft', { value: formatTimeLeft(bid.timeLeftSec) })}
+                      {hasEnded
+                        ? t('profile.bids.ended')
+                        : t('profile.bids.timeLeft', { value: timeRemaining })}
                     </p>
                   </div>
                   <div className="rounded-2xl border border-border/70 bg-background/80 p-3">

--- a/src/pages/ProfileWatchlist.tsx
+++ b/src/pages/ProfileWatchlist.tsx
@@ -91,6 +91,8 @@ const ProfileWatchlist = () => {
           {watchlist.map(item => {
             const auction = lookupAuction(item);
             const seller = auction?.seller;
+            const hasEnded = (auction?.timeLeftSec ?? 0) <= 0;
+            const timeRemaining = auction ? formatTimeLeft(auction.timeLeftSec, locale) : null;
 
             return (
               <article
@@ -122,7 +124,9 @@ const ProfileWatchlist = () => {
                     </p>
                     {auction && (
                       <p className="mt-1 text-xs text-muted-foreground">
-                        {t('profile.watchlist.timeLeft', { value: formatTimeLeft(auction.timeLeftSec) })}
+                        {hasEnded
+                          ? t('profile.watchlist.ended')
+                          : t('profile.watchlist.timeLeft', { value: timeRemaining })}
                       </p>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- restyle the profile auction quick links into compact two-column buttons and drop the duplicate profile nav pill
- localize auction countdown formatting and show locale-aware "ended" messaging across profile and auction views
- extend translations with ended labels for bids and watchlist and route updated countdown labels through i18n

## Testing
- npm run lint *(fails: npm install cannot fetch dependencies due to 403 on ajv)*

------
https://chatgpt.com/codex/tasks/task_e_68d55f3261508324aea43e727f1ae234