### PR TITLE
Add bottom navigation and refresh auctions header

### DIFF
--- a/src/components/auctions/AuctionsFeed.tsx
+++ b/src/components/auctions/AuctionsFeed.tsx
@@ -8,9 +8,10 @@ import type { AuctionListing } from '@/types/auctions';
 import type { Session } from '@/types';
 import { Badge } from '@/components/ui/badge';
 import { useI18n } from '@/context/I18nContext';
-import { AppNav } from '@/components/navigation/AppNav';
 import { AccountSheet, LanguageToggle } from '@/components/shell/AccountControls';
 import { Logo } from '@/components/Logo';
+import { Input } from '@/components/ui/input';
+import { Search } from 'lucide-react';
 
 type AuctionsFeedProps = {
   variant?: 'embedded' | 'page';
@@ -24,6 +25,7 @@ export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProp
   const { t } = useI18n();
   const [selectedAuction, setSelectedAuction] = useState<AuctionListing | null>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
+  const [searchTerm, setSearchTerm] = useState('');
   const headerRef = useRef<HTMLElement | null>(null);
 
   const auctions = useMemo(() => (AUCTION_LISTINGS.length > 0 ? AUCTION_LISTINGS : []), []);
@@ -74,6 +76,18 @@ export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProp
     setSelectedAuction(auction);
   };
 
+  const filteredAuctions = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) return auctions;
+    return auctions.filter(auction => {
+      const haystack = [auction.title, auction.category, auction.seller?.name]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [auctions, searchTerm]);
+
   const handleCloseBidSheet = () => {
     setSelectedAuction(null);
   };
@@ -113,31 +127,49 @@ export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProp
                     {session && <AccountSheet session={session} />}
                   </div>
                 </div>
-                <AppNav className="justify-start" />
+                <div className="relative mt-1">
+                  <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={searchTerm}
+                    onChange={event => setSearchTerm(event.target.value)}
+                    placeholder={t('auctions.searchPlaceholder')}
+                    className="h-12 rounded-full border border-border/60 bg-white/90 pl-11 pr-4 text-sm shadow-soft focus-visible:border-primary focus-visible:ring-0"
+                    aria-label={t('auctions.searchPlaceholder')}
+                  />
+                </div>
               </div>
             </header>
             <div aria-hidden className="shrink-0" style={{ height: headerHeight }} />
           </>
         )}
 
-        <div className={isPage ? 'flex-1 px-5 pb-10 pt-4' : 'px-6 py-6'}>
+        <div className={isPage ? 'flex-1 px-5 pb-28 pt-4' : 'px-6 py-6'}>
           <div className={`mx-auto w-full ${isPage ? 'max-w-6xl' : ''}`}>
             {usingDemoData && (
               <Badge variant="outline" className="mb-4 inline-flex items-center gap-1 rounded-full border-dashed border-border/70 bg-card/80 px-3 py-1 text-[11px] font-medium text-muted-foreground">
                 {t('home.demoData')}
               </Badge>
             )}
-            <div className="grid gap-4">
-              {auctions.map(auction => (
-                <AuctionCard
-                  key={auction.id}
-                  auction={auction}
-                  onViewDetails={handleViewDetails}
-                  onViewSeller={handleViewSeller}
-                  onPlaceBid={handlePlaceBid}
-                />
-              ))}
-            </div>
+            {filteredAuctions.length > 0 ? (
+              <div className="grid gap-4">
+                {filteredAuctions.map(auction => (
+                  <AuctionCard
+                    key={auction.id}
+                    auction={auction}
+                    onViewDetails={handleViewDetails}
+                    onViewSeller={handleViewSeller}
+                    onPlaceBid={handlePlaceBid}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-2 rounded-3xl border border-border/60 bg-card/80 px-6 py-12 text-center shadow-soft">
+                <Badge variant="secondary" className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                  {t('home.searchNoResults')}
+                </Badge>
+                <p className="text-sm text-muted-foreground">{t('auctions.searchEmpty')}</p>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -33,7 +33,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { Badge } from '@/components/ui/badge';
 import { useI18n } from '@/context/I18nContext';
 import { ListingCard } from './ListingCard';
-import { AppNav } from '@/components/navigation/AppNav';
 import type { ListingSummary, Session } from '@/types';
 import { trackEvent } from '@/lib/analytics';
 import { AccountSheet, LanguageToggle } from '@/components/shell/AccountControls';
@@ -1005,25 +1004,22 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
               </button>
             </div>
 
-            <div className="flex flex-col gap-3">
-              <AppNav className="justify-start" />
-              {filterPills.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {filterPills.map(pill => (
-                    <button
-                      key={pill.key}
-                      type="button"
-                      onClick={pill.onRemove}
-                      className="pill bg-white/70 text-muted-foreground hover:border-primary/40 hover:text-primary"
-                      aria-label={t('home.removeFilter', { label: pill.label })}
-                    >
-                      <span className="truncate">{pill.label}</span>
-                      <X className="h-3 w-3" />
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            {filterPills.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {filterPills.map(pill => (
+                  <button
+                    key={pill.key}
+                    type="button"
+                    onClick={pill.onRemove}
+                    className="pill bg-white/70 text-muted-foreground hover:border-primary/40 hover:text-primary"
+                    aria-label={t('home.removeFilter', { label: pill.label })}
+                  >
+                    <span className="truncate">{pill.label}</span>
+                    <X className="h-3 w-3" />
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </header>
 

--- a/src/components/home/HomeFeedWithToggle.tsx
+++ b/src/components/home/HomeFeedWithToggle.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { ModeToggle } from './ModeToggle';
 import { AuctionsFeed } from '@/components/auctions/AuctionsFeed';
 import { HomeFeed } from './HomeFeed';
+import { AppBottomNav } from '@/components/navigation/AppBottomNav';
 import type { Session } from '@/types';
 
 type Mode = 'preorder' | 'auctions';
@@ -27,19 +28,22 @@ export const HomeFeedWithToggle = ({ session }: HomeFeedWithToggleProps) => {
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex justify-center px-6 pt-6">
-        <ModeToggle currentMode={currentMode} onModeChange={handleModeChange} />
-      </div>
+    <>
+      <div className="space-y-6 pb-28">
+        <div className="flex justify-center px-6 pt-6">
+          <ModeToggle currentMode={currentMode} onModeChange={handleModeChange} />
+        </div>
 
-      {currentMode === 'preorder' ? (
-        <HomeFeed session={session} />
-      ) : (
-        <AuctionsFeed
-          session={session}
-          variant={location.pathname === '/auctions' ? 'page' : 'embedded'}
-        />
-      )}
-    </div>
+        {currentMode === 'preorder' ? (
+          <HomeFeed session={session} />
+        ) : (
+          <AuctionsFeed
+            session={session}
+            variant={location.pathname === '/auctions' ? 'page' : 'embedded'}
+          />
+        )}
+      </div>
+      <AppBottomNav />
+    </>
   );
 };

--- a/src/components/navigation/AppBottomNav.tsx
+++ b/src/components/navigation/AppBottomNav.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Gavel, ShoppingBag } from 'lucide-react';
+import { useI18n } from '@/context/I18nContext';
+import { cn } from '@/lib/utils';
+
+type NavVisibility = 'visible' | 'hidden';
+
+const SCROLL_THRESHOLD = 8;
+const RESTORE_DELAY = 160;
+
+export const AppBottomNav = () => {
+  const { t } = useI18n();
+  const location = useLocation();
+  const lastScrollY = useRef(0);
+  const restoreTimeout = useRef<number | null>(null);
+  const [visibility, setVisibility] = useState<NavVisibility>('visible');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    lastScrollY.current = window.scrollY;
+
+    const handleScroll = () => {
+      const currentY = window.scrollY;
+      const delta = currentY - lastScrollY.current;
+      lastScrollY.current = currentY;
+
+      if (delta > SCROLL_THRESHOLD && currentY > 24) {
+        setVisibility('hidden');
+      } else if (delta < -SCROLL_THRESHOLD || Math.abs(delta) <= SCROLL_THRESHOLD) {
+        setVisibility('visible');
+      }
+
+      if (restoreTimeout.current) {
+        window.clearTimeout(restoreTimeout.current);
+      }
+
+      restoreTimeout.current = window.setTimeout(() => {
+        setVisibility('visible');
+      }, RESTORE_DELAY);
+    };
+
+    const handleBlur = () => {
+      setVisibility('visible');
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('blur', handleBlur);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('blur', handleBlur);
+      if (restoreTimeout.current) {
+        window.clearTimeout(restoreTimeout.current);
+      }
+    };
+  }, []);
+
+  const items = useMemo(
+    () => [
+      {
+        key: 'preorder',
+        label: t('navigation.preorder'),
+        href: '/',
+        icon: ShoppingBag,
+        active: location.pathname === '/',
+      },
+      {
+        key: 'auctions',
+        label: t('navigation.auctions'),
+        href: '/auctions',
+        icon: Gavel,
+        active: location.pathname === '/auctions' || location.pathname.startsWith('/auction'),
+      },
+    ],
+    [location.pathname, t]
+  );
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)]">
+      <nav
+        className={cn(
+          'pointer-events-auto w-full max-w-xl rounded-3xl border border-border/60 bg-background/95 shadow-[0_-12px_40px_-22px_rgba(15,23,42,0.55)] backdrop-blur transition-all duration-300',
+          visibility === 'visible' ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'
+        )}
+        aria-label={t('navigation.aria')}
+      >
+        <div className="flex items-center justify-around px-3 py-2">
+          {items.map(item => {
+            const Icon = item.icon;
+            return (
+              <Link
+                key={item.key}
+                to={item.href}
+                className={cn(
+                  'group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide transition-colors',
+                  item.active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+                )}
+                aria-current={item.active ? 'page' : undefined}
+              >
+                <span
+                  className={cn(
+                    'flex h-11 w-11 items-center justify-center rounded-2xl border border-transparent transition-all duration-200',
+                    item.active
+                      ? 'bg-gradient-to-br from-primary via-teal-500 to-blue-500 text-white shadow-[0_8px_18px_rgba(15,191,109,0.35)]'
+                      : 'bg-muted/40 text-muted-foreground shadow-inner group-hover:border-primary/30 group-hover:text-primary'
+                  )}
+                >
+                  <Icon className="h-5 w-5" strokeWidth={2.4} />
+                </span>
+                <span className="font-medium normal-case tracking-normal">{item.label}</span>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+    </div>
+  );
+};
+
+export default AppBottomNav;

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -127,6 +127,8 @@ const translations = {
       laneOnTime: '{{percent}}% on-time',
       sellerByline: 'Seller: {{name}}',
       ended: 'Ended',
+      searchPlaceholder: 'Search auctions',
+      searchEmpty: 'Try refining your search or check back soon.',
     },
     share: {
       sheetTitleListing: 'Share listing',
@@ -1162,6 +1164,8 @@ const translations = {
       laneOnTime: '{{percent}} % à l’heure',
       sellerByline: 'Vendeur : {{name}}',
       ended: 'Terminé',
+      searchPlaceholder: 'Rechercher des enchères',
+      searchEmpty: 'Affinez votre recherche ou revenez plus tard.',
     },
     share: {
       sheetTitleListing: 'Partager l’annonce',


### PR DESCRIPTION
## Summary
- add a professional bottom navigation with preorder and auction entry points that responds to scroll direction
- remove the preorder/auction pills from the home and auction headers to let the bottom nav take over primary navigation
- surface an inline auction search bar with filtering feedback and translated strings

## Testing
- npm run lint *(fails: missing @eslint/js dependency and npm install blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68d56b44ccc88324a171762553c6b13f