### PR TITLE
Align navigation controls with new layout

### DIFF
--- a/src/components/auctions/AuctionsFeed.tsx
+++ b/src/components/auctions/AuctionsFeed.tsx
@@ -8,7 +8,7 @@ import type { AuctionListing } from '@/types/auctions';
 import type { Session } from '@/types';
 import { Badge } from '@/components/ui/badge';
 import { useI18n } from '@/context/I18nContext';
-import { AccountSheet, LanguageToggle } from '@/components/shell/AccountControls';
+import { AccountSheet } from '@/components/shell/AccountControls';
 import { Logo } from '@/components/Logo';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
@@ -123,7 +123,6 @@ export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProp
                     )}
                   </div>
                   <div className="order-2 ml-auto flex items-center gap-2 sm:order-3 sm:ml-0 sm:gap-3">
-                    <LanguageToggle className="h-11 rounded-full border border-border/70 bg-white px-4 text-xs font-semibold uppercase text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary" />
                     {session && <AccountSheet session={session} />}
                   </div>
                 </div>

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -35,7 +35,7 @@ import { useI18n } from '@/context/I18nContext';
 import { ListingCard } from './ListingCard';
 import type { ListingSummary, Session } from '@/types';
 import { trackEvent } from '@/lib/analytics';
-import { AccountSheet, LanguageToggle } from '@/components/shell/AccountControls';
+import { AccountSheet } from '@/components/shell/AccountControls';
 import { useIntersectionOnce } from '@/hooks/use-intersection-once';
 import { cn } from '@/lib/utils';
 import { activateDemoMode, DEMO_LISTINGS, isDemoActive } from '@/lib/demoMode';
@@ -955,20 +955,110 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
                 )}
               </div>
               <div className="order-2 ml-auto flex items-center gap-2 sm:order-3 sm:ml-0 sm:gap-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className={cn(
-                    'inline-flex h-11 items-center gap-2 rounded-full border border-border/70 bg-white px-4 text-sm font-semibold text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40',
-                    activeFilterCount > 0 ? 'border-primary bg-primary/15 text-primary' : '',
-                  )}
-                  onClick={() => handleFilterOpen(true)}
-                  aria-label={filterLabel}
-                >
-                  <Filter className="h-4 w-4" />
-                  <span className="hidden sm:inline">{filterLabel}</span>
-                </Button>
-                <LanguageToggle className="h-11 rounded-full border border-border/70 bg-white px-4 text-xs font-semibold uppercase text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary" />
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className={cn(
+                      'inline-flex h-11 items-center gap-2 rounded-full border border-border/70 bg-white px-4 text-sm font-semibold text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40',
+                      activeFilterCount > 0 ? 'border-primary bg-primary/15 text-primary' : '',
+                    )}
+                    onClick={() => handleFilterOpen(true)}
+                    aria-label={filterLabel}
+                  >
+                    <Filter className="h-4 w-4" />
+                    <span className="hidden sm:inline">{filterLabel}</span>
+                  </Button>
+                  <Popover open={sortMenuOpen} onOpenChange={setSortMenuOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="flex h-11 w-11 items-center justify-center rounded-full border border-border bg-card/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
+                        aria-label={t('home.sortMenu')}
+                        aria-expanded={sortMenuOpen}
+                      >
+                        <ListFilter className="h-5 w-5" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-56 rounded-3xl border border-border bg-card/95 p-3 shadow-soft backdrop-blur">
+                      <div className="space-y-2">
+                        <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {t('home.sortMenu')}
+                        </p>
+                        <div className="flex flex-col gap-2">
+                          {(Object.keys(sortLabels) as SortOption[]).map(option => (
+                            <button
+                              key={option}
+                              type="button"
+                              onClick={() => {
+                                handleSortChange(option);
+                                setSortMenuOpen(false);
+                              }}
+                              className={cn(
+                                'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
+                                option === sort
+                                  ? 'border-primary bg-primary text-primary-foreground shadow-soft'
+                                  : 'border-border bg-card text-muted-foreground hover:border-primary/40',
+                              )}
+                              aria-pressed={option === sort}
+                            >
+                              <span className="truncate">{sortLabels[option]}</span>
+                              {option === sort && <Check className="h-4 w-4" />}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                  <Popover open={categoryMenuOpen} onOpenChange={setCategoryMenuOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="flex h-11 w-11 items-center justify-center rounded-full border border-border bg-card/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
+                        aria-label={t('home.categoriesMenu')}
+                        aria-expanded={categoryMenuOpen}
+                      >
+                        <Grid2X2 className="h-5 w-5" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-64 rounded-3xl border border-border bg-card/95 p-3 shadow-soft backdrop-blur">
+                      <div className="space-y-2">
+                        <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {t('home.categoriesMenu')}
+                        </p>
+                        <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                          {categories.map(category => (
+                            <button
+                              key={category}
+                              type="button"
+                              onClick={() => {
+                                setSelectedCategory(category);
+                                trackEvent('category_chip_click', { category });
+                                setCategoryMenuOpen(false);
+                              }}
+                              className={cn(
+                                'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
+                                selectedCategory === category
+                                  ? 'border-primary bg-primary text-primary-foreground shadow-soft'
+                                  : 'border-border bg-card text-muted-foreground hover:border-primary/40',
+                              )}
+                              aria-pressed={selectedCategory === category}
+                            >
+                              <span className="truncate">
+                                {category === ALL_CATEGORY ? t('home.categoriesAll') : category}
+                              </span>
+                              {selectedCategory === category && <Check className="h-4 w-4" />}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
                 <AccountSheet session={session} />
               </div>
               <button
@@ -1157,97 +1247,6 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
         </DrawerContent>
       </Drawer>
 
-      <div className="fixed bottom-6 left-6 z-50 flex flex-col gap-3 sm:flex-row">
-        <Popover open={sortMenuOpen} onOpenChange={setSortMenuOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
-              aria-label={t('home.sortMenu')}
-              aria-expanded={sortMenuOpen}
-            >
-              <ListFilter className="h-5 w-5" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-56 rounded-3xl border border-border bg-card/95 p-3 shadow-soft backdrop-blur">
-            <div className="space-y-2">
-              <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                {t('home.sortMenu')}
-              </p>
-              <div className="flex flex-col gap-2">
-                {(Object.keys(sortLabels) as SortOption[]).map(option => (
-                  <button
-                    key={option}
-                    type="button"
-                    onClick={() => {
-                      handleSortChange(option);
-                      setSortMenuOpen(false);
-                    }}
-                    className={cn(
-                      'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
-                      option === sort
-                        ? 'border-primary bg-primary text-primary-foreground shadow-soft'
-                        : 'border-border bg-card text-muted-foreground hover:border-primary/40',
-                    )}
-                    aria-pressed={option === sort}
-                  >
-                    <span className="truncate">{sortLabels[option]}</span>
-                    {option === sort && <Check className="h-4 w-4" />}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
-        <Popover open={categoryMenuOpen} onOpenChange={setCategoryMenuOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card/90 text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary"
-              aria-label={t('home.categoriesMenu')}
-              aria-expanded={categoryMenuOpen}
-            >
-              <Grid2X2 className="h-5 w-5" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-64 rounded-3xl border border-border bg-card/95 p-3 shadow-soft backdrop-blur">
-            <div className="space-y-2">
-              <p className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                {t('home.categoriesMenu')}
-              </p>
-              <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
-                {categories.map(category => (
-                  <button
-                    key={category}
-                    type="button"
-                    onClick={() => {
-                      setSelectedCategory(category);
-                      trackEvent('category_chip_click', { category });
-                      setCategoryMenuOpen(false);
-                    }}
-                    className={cn(
-                      'flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors',
-                      selectedCategory === category
-                        ? 'border-primary bg-primary text-primary-foreground shadow-soft'
-                        : 'border-border bg-card text-muted-foreground hover:border-primary/40',
-                    )}
-                    aria-pressed={selectedCategory === category}
-                  >
-                    <span className="truncate">
-                      {category === ALL_CATEGORY ? t('home.categoriesAll') : category}
-                    </span>
-                    {selectedCategory === category && <Check className="h-4 w-4" />}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
-      </div>
 
       <main className="flex-1 space-y-6 px-6 pb-24 pt-6">
         {fallbackActive && (

--- a/src/components/navigation/AppBottomNav.tsx
+++ b/src/components/navigation/AppBottomNav.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Gavel, ShoppingBag } from 'lucide-react';
+import { Bell, Gavel, PlusCircle, ShoppingBag } from 'lucide-react';
 import { useI18n } from '@/context/I18nContext';
 import { cn } from '@/lib/utils';
 
@@ -64,6 +64,7 @@ export const AppBottomNav = () => {
         label: t('navigation.preorder'),
         href: '/',
         icon: ShoppingBag,
+        color: 'text-primary',
         active: location.pathname === '/',
       },
       {
@@ -71,22 +72,44 @@ export const AppBottomNav = () => {
         label: t('navigation.auctions'),
         href: '/auctions',
         icon: Gavel,
-        active: location.pathname === '/auctions' || location.pathname.startsWith('/auction'),
+        color: 'text-sky-500',
+        active:
+          location.pathname === '/auctions' ||
+          location.pathname.startsWith('/auction'),
+      },
+      {
+        key: 'add',
+        label: t('navigation.add'),
+        href: '/importer/create',
+        icon: PlusCircle,
+        color: 'text-teal-500',
+        active: location.pathname.startsWith('/importer/create'),
+      },
+      {
+        key: 'notifications',
+        label: t('navigation.notifications'),
+        href: '/account#notifications',
+        icon: Bell,
+        color: 'text-blue-500',
+        active:
+          location.pathname.startsWith('/account') &&
+          (location.hash.includes('notifications') ||
+            location.pathname === '/account'),
       },
     ],
-    [location.pathname, t]
+    [location.hash, location.pathname, t]
   );
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)]">
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50">
       <nav
         className={cn(
-          'pointer-events-auto w-full max-w-xl rounded-3xl border border-border/60 bg-background/95 shadow-[0_-12px_40px_-22px_rgba(15,23,42,0.55)] backdrop-blur transition-all duration-300',
-          visibility === 'visible' ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0'
+          'pointer-events-auto border-t border-border/60 bg-background/95 shadow-[0_-12px_30px_-28px_rgba(15,23,42,0.45)] backdrop-blur transition-all duration-300',
+          visibility === 'visible' ? 'translate-y-0 opacity-100' : 'translate-y-8 opacity-0'
         )}
         aria-label={t('navigation.aria')}
       >
-        <div className="flex items-center justify-around px-3 py-2">
+        <div className="mx-auto flex w-full max-w-3xl items-center justify-around px-2 pt-2 pb-[calc(env(safe-area-inset-bottom)+0.35rem)]">
           {items.map(item => {
             const Icon = item.icon;
             return (
@@ -94,20 +117,28 @@ export const AppBottomNav = () => {
                 key={item.key}
                 to={item.href}
                 className={cn(
-                  'group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide transition-colors',
-                  item.active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+                  'group flex flex-1 flex-col items-center gap-1 rounded-xl px-2 py-1 text-[11px] font-semibold uppercase tracking-wide transition-colors',
+                  item.active
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
                 )}
                 aria-current={item.active ? 'page' : undefined}
               >
                 <span
                   className={cn(
-                    'flex h-11 w-11 items-center justify-center rounded-2xl border border-transparent transition-all duration-200',
+                    'flex h-9 w-9 items-center justify-center rounded-2xl border border-transparent transition-all duration-200',
                     item.active
-                      ? 'bg-gradient-to-br from-primary via-teal-500 to-blue-500 text-white shadow-[0_8px_18px_rgba(15,191,109,0.35)]'
-                      : 'bg-muted/40 text-muted-foreground shadow-inner group-hover:border-primary/30 group-hover:text-primary'
+                      ? 'bg-gradient-to-br from-primary via-teal-500 to-blue-500 text-white shadow-[0_10px_20px_rgba(15,191,109,0.35)]'
+                      : 'bg-transparent'
                   )}
                 >
-                  <Icon className="h-5 w-5" strokeWidth={2.4} />
+                  <Icon
+                    className={cn(
+                      'h-5 w-5 transition-colors',
+                      item.active ? 'text-white' : item.color
+                    )}
+                    strokeWidth={2.4}
+                  />
                 </span>
                 <span className="font-medium normal-case tracking-normal">{item.label}</span>
               </Link>

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -178,6 +178,8 @@ const translations = {
     navigation: {
       preorder: 'Preorder',
       auctions: 'Auctions',
+      add: 'Add',
+      notifications: 'Notifications',
       profile: 'Profile',
       aria: 'Primary navigation',
     },
@@ -1215,6 +1217,8 @@ const translations = {
     navigation: {
       preorder: 'Précommande',
       auctions: 'Enchères',
+      add: 'Ajouter',
+      notifications: 'Notifications',
       profile: 'Profil',
       aria: 'Navigation principale',
     },

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,7 +4,7 @@ import { useSession } from '@/context/SessionContext';
 import { useI18n } from '@/context/I18nContext';
 import type { Session } from '@/types';
 import { HomeFeedWithToggle } from '@/components/home/HomeFeedWithToggle';
-import { AccountSheet, LanguageToggle, languageNames } from '@/components/shell/AccountControls';
+import { AccountSheet, languageNames } from '@/components/shell/AccountControls';
 import { ImporterDashboard } from '@/components/importer/ImporterDashboard';
 import { Logo } from '@/components/Logo';
 import { InstallPwaButton } from '@/components/pwa/InstallPwaButton';
@@ -46,7 +46,6 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
           <div className="flex flex-wrap items-center gap-3">
             <span className="pill bg-primary/20 text-primary normal-case">{modeLabel}</span>
             <span className="pill bg-white/75 text-muted-foreground/80 normal-case">{languageNames[locale]}</span>
-            <LanguageToggle className="hidden h-10 items-center rounded-full border border-white/50 bg-white/80 px-4 text-xs font-semibold uppercase text-muted-foreground shadow-soft transition-all hover:border-primary/40 hover:text-primary sm:inline-flex" />
           </div>
         </header>
 


### PR DESCRIPTION
## Summary
- update the bottom navigation to sit flush on screen edges and add dedicated Add and Notifications buttons
- move sort and category popovers beside the filter control and drop the header language toggle in favor of the account sheet
- extend navigation translations for the new actions

## Testing
- npm run lint *(fails: missing @eslint/js due to npm install 403 restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d5701234908324b78e56dbb00ed343