### PR TITLE
Update logo placeholder to use new transparent asset

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,20 +1,38 @@
-import type { ImgHTMLAttributes } from 'react';
+import type { CSSProperties, ImgHTMLAttributes } from 'react';
 import { useI18n } from '@/context/I18nContext';
 import { cn } from '@/lib/utils';
 
-export type LogoProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'>;
+export type LogoProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
+  wrapperClassName?: string;
+  wrapperStyle?: CSSProperties;
+};
 
-export const Logo = ({ className, alt, style, ...props }: LogoProps) => {
+export const Logo = ({
+  className,
+  alt,
+  style,
+  wrapperClassName,
+  wrapperStyle,
+  ...props
+}: LogoProps) => {
   const { t } = useI18n();
 
   return (
-    <img
-      src="/images/logo.png"
-      alt={alt ?? t('app.name')} 
-      className={cn('h-12 w-auto', className)}
-      style={{ clipPath: 'inset(6%)', ...style }}
-      {...props}
-    />
+    <div
+      className={cn(
+        'inline-flex h-12 w-12 items-center justify-center rounded-3xl bg-gradient-to-br from-primary via-teal to-blue p-2',
+        wrapperClassName,
+      )}
+      style={wrapperStyle}
+    >
+      <img
+        src="/images/logo-transparent.png"
+        alt={alt ?? t('app.name')}
+        className={cn('h-full w-full rounded-2xl object-contain', className)}
+        style={style}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/src/components/auctions/AuctionsFeed.tsx
+++ b/src/components/auctions/AuctionsFeed.tsx
@@ -113,7 +113,7 @@ export const AuctionsFeed = ({ variant = 'embedded', session }: AuctionsFeedProp
                 <div className="flex flex-wrap items-center gap-3 sm:gap-4">
                   <div className="order-1 flex items-center gap-3">
                     <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-border/60 bg-gradient-to-br from-primary/10 via-teal/5 to-blue/10 shadow-soft">
-                      <Logo className="h-8 w-auto" />
+                      <Logo wrapperClassName="h-8 w-8" />
                     </div>
                     <span className="text-lg font-semibold tracking-tight text-foreground">ProList</span>
                     {PREVIEW_BADGE_VISIBLE && (

--- a/src/components/auth/SignInFlow.tsx
+++ b/src/components/auth/SignInFlow.tsx
@@ -138,7 +138,7 @@ export const SignInFlow = ({ onAuthenticated }: SignInFlowProps) => {
           )}
 
           <div className="flex flex-col items-center gap-4 text-center">
-            <Logo className="h-12 w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
+            <Logo wrapperClassName="h-12 w-12 drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/80">{t('app.tagline')}</p>
               <h1 className="text-3xl font-semibold tracking-tight">{t('auth.welcome')}</h1>

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -945,7 +945,7 @@ export const HomeFeed = ({ session }: HomeFeedProps) => {
             <div className="flex flex-wrap items-center gap-3 sm:gap-4">
               <div className="order-1 flex items-center gap-3">
                 <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-border/60 bg-gradient-to-br from-primary/10 via-teal/5 to-blue/10 shadow-soft">
-                  <Logo className="h-8 w-auto" />
+                  <Logo wrapperClassName="h-8 w-8" />
                 </div>
                 <span className="text-lg font-semibold tracking-tight text-foreground">ProList</span>
                 {PREVIEW_BADGE_VISIBLE && (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -34,7 +34,7 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
             <div className="flex items-center justify-end gap-3 sm:order-3">
               <InstallPwaButton className="shadow-glow sm:order-2" />
               <div className="glass-card inline-flex items-center justify-center rounded-3xl p-3 shadow-lux">
-                <Logo className="h-[4.5rem] w-auto drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
+                <Logo wrapperClassName="h-[4.5rem] w-[4.5rem] drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
               </div>
               {showPreviewBadge && (
                 <Badge variant="outline" className="rounded-full border-dashed px-2.5 py-0.5 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- replace the logo component to render the new transparent asset inside a gradient square wrapper
- update all logo usages to size the new placeholder and preserve existing decorative styles

## Testing
- npm run lint *(fails: cannot find package '@eslint/js' because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5811286ec8324b09b9b13db186042