### PR TITLE
Adjust logo scaling and placeholder

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -20,7 +20,7 @@ export const Logo = ({
   return (
     <div
       className={cn(
-        'inline-flex h-12 w-12 items-center justify-center rounded-3xl bg-gradient-to-br from-primary via-teal to-blue p-2',
+        'inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-teal to-blue',
         wrapperClassName,
       )}
       style={wrapperStyle}
@@ -28,7 +28,10 @@ export const Logo = ({
       <img
         src="/images/logo-transparent.png"
         alt={alt ?? t('app.name')}
-        className={cn('h-full w-full rounded-2xl object-contain', className)}
+        className={cn(
+          'h-full w-full origin-center rounded-2xl object-cover transform scale-[3]',
+          className,
+        )}
         style={style}
         {...props}
       />


### PR DESCRIPTION
## Summary
- enlarge the logo asset within its existing gradient placeholder
- hide the placeholder's overflow to clip scaled imagery and remove transparent edging

## Testing
- npm run lint *(fails: missing dependency `@eslint/js` due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d58425a66c8324b49b9f6e5eb9db93