### PR TITLE
Adjust logo sizing

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -29,7 +29,7 @@ export const Logo = ({
         src="/images/logo-transparent.png"
         alt={alt ?? t('app.name')}
         className={cn(
-          'h-full w-full origin-center rounded-2xl object-cover transform scale-[3]',
+          'h-full w-full origin-center rounded-2xl object-contain',
           className,
         )}
         style={style}


### PR DESCRIPTION
## Summary
- switch the logo image to use `object-contain` so it stays within its gradient wrapper

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d58594d3ac832489750ddf68d502f6