### PR TITLE
Update auction pricing styling

### DIFF
--- a/src/components/auctions/AuctionCard.tsx
+++ b/src/components/auctions/AuctionCard.tsx
@@ -180,19 +180,19 @@ export const AuctionCard = ({ auction, onViewDetails, onViewSeller, onPlaceBid }
               </p>
             )}
             <div className="flex items-start justify-between gap-3">
-              <div className="space-y-0.5">
-                <span className="text-[11px] font-semibold uppercase tracking-wide text-blue/80">
+              <div className="space-y-1 rounded-full border border-blue/40 bg-white/70 px-3 py-2">
+                <span className="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   {t('auctions.startedAt')}
                 </span>
-                <p className="text-xs font-semibold text-blue">
+                <p className="text-xs font-semibold text-muted-foreground">
                   {currencyFormatter.format(startingBidXAF)}
                 </p>
               </div>
-              <div className="space-y-0.5 text-right">
-                <span className="text-[11px] font-semibold uppercase tracking-wide text-primary/80">
+              <div className="space-y-1 rounded-full border border-primary/50 bg-white/70 px-3 py-2 text-right">
+                <span className="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   {t('auctions.currentBid')}
                 </span>
-                <p className="text-xs font-semibold text-primary">
+                <p className="text-xs font-semibold text-muted-foreground">
                   {currencyFormatter.format(auction.currentBidXAF)}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- match the started and current price typography with the seller text styling
- wrap the pricing sections in subtle circular borders that use the brand accent colors for a minimal look

## Testing
- npm run lint *(fails: missing @eslint/js package due to registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d58ad3b2908324a9bdb9b7d7ecf491