### PR TITLE
Adjust auction card bid styling

### DIFF
--- a/src/components/auctions/AuctionCard.tsx
+++ b/src/components/auctions/AuctionCard.tsx
@@ -180,19 +180,19 @@ export const AuctionCard = ({ auction, onViewDetails, onViewSeller, onPlaceBid }
               </p>
             )}
             <div className="flex items-start justify-between gap-3">
-              <div className="space-y-1 rounded-full border border-blue/40 bg-white/70 px-3 py-2">
+              <div className="space-y-1 rounded-full bg-white/70 px-3 py-2">
                 <span className="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   {t('auctions.startedAt')}
                 </span>
-                <p className="text-xs font-semibold text-muted-foreground">
+                <p className="text-xs font-bold text-muted-foreground">
                   {currencyFormatter.format(startingBidXAF)}
                 </p>
               </div>
-              <div className="space-y-1 rounded-full border border-primary/50 bg-white/70 px-3 py-2 text-right">
+              <div className="space-y-1 rounded-full bg-white/70 px-3 py-2 text-right">
                 <span className="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   {t('auctions.currentBid')}
                 </span>
-                <p className="text-xs font-semibold text-muted-foreground">
+                <p className="text-xs font-bold text-muted-foreground">
                   {currencyFormatter.format(auction.currentBidXAF)}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- remove border outlines from the "Started at" and "Current bid" pills on auction cards
- bold the corresponding bid amounts for stronger emphasis

## Testing
- npm run lint *(fails: missing @eslint/js dependency prior to install)*
- npm install *(fails: npm registry forbidden; prevents installing lint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d58c6940dc832482011304bd6ae761