### PR TITLE
Fix auction card bid layout and styling

### DIFF
--- a/src/components/auctions/AuctionCard.tsx
+++ b/src/components/auctions/AuctionCard.tsx
@@ -181,18 +181,18 @@ export const AuctionCard = ({ auction, onViewDetails, onViewSeller, onPlaceBid }
             )}
             <div className="flex items-start justify-between gap-3">
               <div className="space-y-1 rounded-full bg-white/70 px-3 py-2">
-                <span className="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                <span className="block whitespace-nowrap text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   {t('auctions.startedAt')}
                 </span>
-                <p className="text-xs font-bold text-muted-foreground">
+                <p className="inline-flex items-center justify-center rounded-full bg-blue/10 px-2 py-1 text-xs font-semibold text-blue">
                   {currencyFormatter.format(startingBidXAF)}
                 </p>
               </div>
               <div className="space-y-1 rounded-full bg-white/70 px-3 py-2 text-right">
-                <span className="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                <span className="block whitespace-nowrap text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   {t('auctions.currentBid')}
                 </span>
-                <p className="text-xs font-bold text-muted-foreground">
+                <p className="inline-flex items-center justify-center rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
                   {currencyFormatter.format(auction.currentBidXAF)}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- prevent the current bid label from wrapping onto multiple lines on the auction card
- highlight the starting and current bid amounts using light brand color pills for better emphasis

## Testing
- `npm run lint` *(fails: Missing dependency @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d58e29336c8324af17ac68ad88378b