### PR TITLE
Remove current bid display from auction card

### DIFF
--- a/src/components/auctions/AuctionCard.tsx
+++ b/src/components/auctions/AuctionCard.tsx
@@ -183,21 +183,13 @@ export const AuctionCard = ({ auction, onViewDetails, onViewSeller, onPlaceBid }
                 {auction.seller.city}
               </p>
             )}
-            <div className="flex items-center justify-between gap-3 rounded-full bg-white/70 px-3 py-2">
+            <div className="flex items-center gap-3 rounded-full bg-white/70 px-3 py-2">
               <div className="flex items-center gap-2">
                 <span className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
                   Start
                 </span>
                 <p className="inline-flex items-center justify-center rounded-full bg-blue/10 px-2 py-1 text-xs font-semibold text-blue">
                   {currencyFormatter.format(startingBidXAF)}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
-                  Current
-                </span>
-                <p className="inline-flex items-center justify-center rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
-                  {currencyFormatter.format(auction.currentBidXAF)}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the current bid section from auction cards to match the new design
- adjust the card layout so the starting bid pill remains aligned without the extra column

## Testing
- npm run lint *(fails: npm ERR 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d59b0ff88883248e2b4ca6bd7bac4c