### PR TITLE
Revamp importer mode header and styling

### DIFF
--- a/src/components/importer/ImporterDashboard.tsx
+++ b/src/components/importer/ImporterDashboard.tsx
@@ -272,25 +272,33 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
 
   return (
     <div className="flex flex-col gap-8">
-      <header className="flex flex-col gap-4 rounded-3xl border border-border bg-gradient-to-br from-muted/40 to-background p-6 shadow-sm">
+      <header className="flex flex-col gap-5 rounded-3xl border border-white/80 bg-gradient-to-br from-white/95 via-primary/5 to-blue/10 p-6 shadow-[0_20px_45px_rgba(14,116,144,0.12)] backdrop-blur">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="space-y-2">
             <div className="flex items-center gap-3">
-              <Badge className="rounded-full bg-primary/10 px-3 py-1 text-primary" variant="outline">
+              <Badge className="rounded-full border-primary/20 bg-primary/15 px-3 py-1 text-primary" variant="outline">
                 {t('roles.importerBadge')}
               </Badge>
-              <span className="text-sm text-muted-foreground">{session.displayName}</span>
+              <span className="text-sm font-medium text-muted-foreground">{session.displayName}</span>
             </div>
-            <h1 className="text-2xl font-semibold text-foreground">{t('importerDashboard.heading')}</h1>
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">{t('importerDashboard.heading')}</h1>
             <p className="text-sm text-muted-foreground">{t('importerDashboard.tagline')}</p>
             <Badge
               variant={session.verifiedImporter ? 'default' : 'outline'}
-              className={`rounded-full px-3 py-1 text-xs ${session.verifiedImporter ? 'bg-emerald-500/10 text-emerald-700' : 'bg-amber-500/10 text-amber-700'}`}
+              className={`rounded-full px-3 py-1 text-xs ${
+                session.verifiedImporter
+                  ? 'border-emerald-500/30 bg-emerald-500/15 text-emerald-700'
+                  : 'border-amber-500/40 bg-amber-500/15 text-amber-700'
+              }`}
             >
               {session.verifiedImporter ? t('dashboard.importerStatusVerified') : t('dashboard.importerStatusPending')}
             </Badge>
           </div>
-          <Button size="lg" className="rounded-full px-6" onClick={() => navigate('/importer/create')}>
+          <Button
+            size="lg"
+            className="rounded-full bg-primary px-6 text-primary-foreground shadow-soft transition-transform hover:-translate-y-0.5"
+            onClick={() => navigate('/importer/create')}
+          >
             {t('importerDashboard.createListing')}
           </Button>
         </div>
@@ -317,8 +325,8 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
                   key={kpi.id}
                   type="button"
                   onClick={() => setSelectedKpi(kpi.id)}
-                  className={`flex h-24 flex-col justify-between rounded-2xl border p-4 text-left transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40 ${
-                    selectedKpi === kpi.id ? 'shadow-md ring-1 ring-primary/30' : 'shadow-sm'
+                  className={`flex h-24 flex-col justify-between rounded-2xl border border-white/60 bg-white/90 p-4 text-left shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-primary/40 ${
+                    selectedKpi === kpi.id ? 'shadow-lg ring-1 ring-primary/30' : 'hover:-translate-y-0.5'
                   }`}
                 >
                   <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -338,10 +346,13 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
         </div>
 
         {listings.length === 0 && !isLoading ? (
-          <Card className="rounded-3xl border-dashed bg-muted/30 p-8 text-center">
+          <Card className="rounded-3xl border border-dashed border-primary/20 bg-white/90 p-8 text-center shadow-soft">
             <h3 className="text-lg font-semibold">{t('importerDashboard.emptyTitle')}</h3>
             <p className="mt-2 text-sm text-muted-foreground">{t('importerDashboard.emptyBody')}</p>
-            <Button className="mt-6 rounded-full" onClick={() => navigate('/importer/create')}>
+            <Button
+              className="mt-6 rounded-full bg-primary px-5 text-primary-foreground shadow-soft"
+              onClick={() => navigate('/importer/create')}
+            >
               {t('importerDashboard.createListing')}
             </Button>
           </Card>
@@ -350,7 +361,7 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
             {isLoading && listings.length === 0 && (
               <div className="space-y-3">
                 {Array.from({ length: 2 }).map((_, index) => (
-                  <Card key={index} className="rounded-3xl p-4">
+                  <Card key={index} className="rounded-3xl border border-white/70 bg-white/90 p-4 shadow-sm">
                     <CardContent className="flex items-center gap-4 p-0">
                       <Skeleton className="h-24 w-24 rounded-2xl" />
                       <div className="flex-1 space-y-3">
@@ -371,19 +382,19 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
               return (
                 <Card
                   key={listing.id}
-                  className="group relative overflow-hidden rounded-3xl border border-border/80 bg-background/95 p-4 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-lg"
+                  className="group relative overflow-hidden rounded-3xl border border-white/70 bg-white/95 p-4 shadow-[0_18px_45px_rgba(15,118,180,0.08)] transition-all hover:-translate-y-0.5 hover:shadow-[0_26px_60px_rgba(15,118,180,0.12)]"
                 >
                   <CardContent className="flex gap-4 p-0">
-                    <div className="h-24 w-24 shrink-0 overflow-hidden rounded-2xl bg-muted">
+                    <div className="h-24 w-24 shrink-0 overflow-hidden rounded-2xl border border-white/70 bg-muted shadow-inner">
                       <img src={listing.image} alt={listing.title} className="h-full w-full object-cover" />
                     </div>
                     <div className="flex flex-1 flex-col gap-4">
                       <div className="flex flex-col gap-2">
-                        <div className="flex items-start justify-between gap-3">
-                          <div>
-                            <h3 className="text-base font-semibold text-foreground">{listing.title}</h3>
-                            <p className="text-sm text-muted-foreground">{formatPrice(listing.priceXAF, locale)}</p>
-                          </div>
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <h3 className="text-base font-semibold tracking-tight text-foreground">{listing.title}</h3>
+                              <p className="text-sm text-muted-foreground">{formatPrice(listing.priceXAF, locale)}</p>
+                            </div>
                           <Badge className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${statusToneClass(listing.status)}`}>
                             {statusLabel(listing.status, locale)}
                           </Badge>
@@ -398,7 +409,7 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
                           <span className="text-muted-foreground">{locksInCopy(listing.moq.lockAt, locale)}</span>
                         </div>
                         <div className="space-y-2">
-                          <Progress value={progressValue} className="h-2 overflow-hidden rounded-full bg-muted" />
+                          <Progress value={progressValue} className="h-2 overflow-hidden rounded-full bg-blue/10" />
                           <div className="flex justify-between text-xs text-muted-foreground">
                             <span>{t('importerDashboard.progressLabel', { committed: listing.moq.committed, target: listing.moq.target })}</span>
                             <span>{formatPct(listing.moq.committed / Math.max(1, listing.moq.target))}</span>
@@ -407,11 +418,21 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
                       </div>
 
                       <div className="flex flex-wrap gap-2">
-                        <Button variant="secondary" size="sm" className="h-11 flex-1 rounded-full" onClick={() => openShare(listing)}>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          className="h-11 flex-1 rounded-full bg-primary/10 text-primary shadow-soft transition-colors hover:bg-primary/20"
+                          onClick={() => openShare(listing)}
+                        >
                           <Share2 className="mr-2 h-4 w-4" />
                           {t('importerDashboard.actions.share')}
                         </Button>
-                        <Button variant="secondary" size="sm" className="h-11 flex-1 rounded-full" onClick={() => openEvidence(listing)}>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          className="h-11 flex-1 rounded-full bg-blue/10 text-blue-700 shadow-soft transition-colors hover:bg-blue/20"
+                          onClick={() => openEvidence(listing)}
+                        >
                           <UploadCloud className="mr-2 h-4 w-4" />
                           {t('importerDashboard.actions.evidence')}
                           {Object.keys(evidence).length > 0 && <span className="ml-2 text-xs text-emerald-600">•</span>}
@@ -423,7 +444,12 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
                           onConfirm={() => markArrived(listing)}
                           disabled={listing.status === 'arrived'}
                         />
-                        <Button variant="outline" size="sm" className="h-11 flex-1 rounded-full" onClick={() => openBuyers(listing)}>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-11 flex-1 rounded-full border-primary/30 text-primary shadow-soft hover:bg-primary/10"
+                          onClick={() => openBuyers(listing)}
+                        >
                           <Users className="mr-2 h-4 w-4" />
                           {t('importerDashboard.actions.buyers')}
                         </Button>
@@ -506,7 +532,7 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
           <div className="mt-6 space-y-4">
             {buyersListing && (
               <>
-                <div className="rounded-2xl border bg-muted/30 p-4 text-sm text-muted-foreground">
+                <div className="rounded-2xl border border-primary/20 bg-primary/10 p-4 text-sm text-primary">
                   {t('importerDashboard.buyersSummary', {
                     count: buyersListing.buyersCount,
                     committed: buyersListing.moq.committed,
@@ -515,7 +541,7 @@ export const ImporterDashboard = ({ session }: ImporterDashboardProps) => {
                 </div>
                 <div className="space-y-3">
                   {buyerNames.slice(0, Math.min(4, buyersListing.buyersCount)).map((name, index) => (
-                    <div key={name} className="flex items-center justify-between rounded-2xl border p-4 text-sm">
+                    <div key={name} className="flex items-center justify-between rounded-2xl border border-white/70 bg-white/95 p-4 text-sm shadow-sm">
                       <div>
                         <p className="font-medium text-foreground">{name}</p>
                         <p className="text-xs text-muted-foreground">
@@ -549,7 +575,12 @@ const AlertDialogTriggerButton = ({ label, onConfirm, disabled }: AlertDialogTri
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button variant="outline" size="sm" className="h-11 flex-1 rounded-full" disabled={disabled}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-11 flex-1 rounded-full border-emerald-500/40 bg-emerald-500/10 text-emerald-700 shadow-soft transition-colors hover:bg-emerald-500/20"
+          disabled={disabled}
+        >
           <PackageCheck className="mr-2 h-4 w-4" />
           {label}
         </Button>
@@ -560,9 +591,11 @@ const AlertDialogTriggerButton = ({ label, onConfirm, disabled }: AlertDialogTri
           <AlertDialogDescription>{t('importerDashboard.arrivedConfirmBody')}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel className="rounded-full px-6">{t('common.cancel')}</AlertDialogCancel>
+          <AlertDialogCancel className="rounded-full px-6 text-muted-foreground hover:bg-muted/40">
+            {t('common.cancel')}
+          </AlertDialogCancel>
           <AlertDialogAction
-            className="rounded-full px-6"
+            className="rounded-full bg-primary px-6 text-primary-foreground shadow-soft hover:bg-primary/90"
             onClick={() => {
               onConfirm();
               setOpen(false);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 import { SignInFlow } from '@/components/auth/SignInFlow';
 import { RoleChooser } from '@/components/auth/RoleChooser';
 import { useSession } from '@/context/SessionContext';
@@ -13,6 +15,33 @@ import { Badge } from '@/components/ui/badge';
 const AuthenticatedShell = ({ session }: { session: Session }) => {
   const { t, locale } = useI18n();
   const showPreviewBadge = import.meta.env.MODE !== 'production' || import.meta.env.DEV;
+  const headerRef = useRef<HTMLElement | null>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useEffect(() => {
+    const node = headerRef.current;
+    if (!node) return;
+
+    const updateHeight = () => {
+      setHeaderHeight(node.getBoundingClientRect().height);
+    };
+
+    updateHeight();
+
+    let observer: ResizeObserver | null = null;
+
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(() => updateHeight());
+      observer.observe(node);
+    }
+
+    window.addEventListener('resize', updateHeight);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
 
   if (session.role === 'buyer') {
     return <HomeFeedWithToggle session={session} />;
@@ -21,36 +50,49 @@ const AuthenticatedShell = ({ session }: { session: Session }) => {
   const modeLabel = t('roles.importerBadge');
 
   return (
-    <main className="relative min-h-dvh overflow-hidden text-foreground">
-      <div className="pointer-events-none absolute inset-0 bg-app-gradient" />
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-white/80 via-white/40 to-transparent" />
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-64 bg-gradient-to-t from-white/80 via-white/30 to-transparent" />
-      <div className="relative z-10 mx-auto flex min-h-dvh w-full max-w-3xl flex-col gap-8 px-6 py-10">
-        <header className="sticky top-6 z-20 flex flex-col gap-5 rounded-3xl bg-background p-6 shadow-soft">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="sm:order-1">
-              <AccountSheet session={session} />
-            </div>
-            <div className="flex items-center justify-end gap-3 sm:order-3">
-              <InstallPwaButton className="shadow-glow sm:order-2" />
-              <div className="glass-card inline-flex items-center justify-center rounded-3xl p-3 shadow-lux">
-                <Logo wrapperClassName="h-[4.5rem] w-[4.5rem] drop-shadow-[0_18px_40px_-16px_rgba(15,191,109,0.45)]" />
+    <main className="relative min-h-dvh overflow-hidden bg-slate-50 text-foreground">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(15,191,109,0.08),transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(14,165,233,0.12),transparent_50%)]" />
+      <div className="relative z-10 flex min-h-dvh flex-col">
+        <header
+          ref={headerRef}
+          className="fixed inset-x-0 top-0 z-40 border-b border-border/40 bg-white/90 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/75"
+        >
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 pb-4 pt-[calc(env(safe-area-inset-top)+1rem)]">
+            <div className="flex flex-wrap items-center gap-3 sm:gap-4">
+              <div className="order-1 flex items-center gap-3">
+                <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-border/60 bg-gradient-to-br from-primary/10 via-teal/5 to-blue/10 shadow-soft">
+                  <Logo wrapperClassName="h-8 w-8" />
+                </div>
+                <span className="text-lg font-semibold tracking-tight text-foreground">ProList</span>
+                {showPreviewBadge && (
+                  <Badge variant="outline" className="rounded-full border-dashed px-2.5 py-0.5 text-[11px] text-muted-foreground">
+                    {t('common.preview')}
+                  </Badge>
+                )}
               </div>
-              {showPreviewBadge && (
-                <Badge variant="outline" className="rounded-full border-dashed px-2.5 py-0.5 text-[11px] text-muted-foreground">
-                  {t('common.preview')}
-                </Badge>
-              )}
+              <div className="order-3 ml-auto flex items-center gap-2 sm:order-4 sm:ml-0 sm:gap-3">
+                <InstallPwaButton className="hidden rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-soft sm:inline-flex" />
+                <AccountSheet session={session} />
+              </div>
             </div>
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <span className="pill bg-primary/20 text-primary normal-case">{modeLabel}</span>
-            <span className="pill bg-white/75 text-muted-foreground/80 normal-case">{languageNames[locale]}</span>
+            <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+              <span className="pill bg-primary/20 text-primary normal-case">{modeLabel}</span>
+              <span className="pill bg-blue/10 text-blue-600 normal-case">{languageNames[locale]}</span>
+              <span className="pill bg-muted/60 text-muted-foreground normal-case">{session.displayName}</span>
+            </div>
           </div>
         </header>
 
-        <div className="glass-card px-4 py-6 shadow-soft">
-          <ImporterDashboard session={session} />
+        <div aria-hidden className="shrink-0" style={{ height: headerHeight }} />
+
+        <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 pb-12 pt-8">
+          <div className="sm:hidden">
+            <InstallPwaButton className="w-full rounded-2xl bg-primary/90 py-3 text-sm font-semibold text-primary-foreground shadow-soft" />
+          </div>
+          <div className="rounded-3xl border border-white/80 bg-white/90 p-4 shadow-[0_22px_55px_rgba(14,116,144,0.08)] backdrop-blur">
+            <ImporterDashboard session={session} />
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- restyled the importer mode shell to mirror the buyers auction header with matching logo and account controls
- introduced a polished blue-forward background and container treatment for the importer landing experience
- refreshed importer dashboard cards, buttons, and dialogs with brand-aligned gradients and accents for a more professional feel

## Testing
- npm run lint *(fails: missing npm dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a4674b648324a5062bcbb346bc24