### PR TITLE
Add vendor role card to account switcher

### DIFF
--- a/src/components/shell/AccountControls.tsx
+++ b/src/components/shell/AccountControls.tsx
@@ -157,6 +157,12 @@ export const AccountSheet = ({ session }: { session: Session }) => {
               description={t('roles.importerSummary')}
               onClick={() => handleRoleChange('importer')}
             />
+            <AccountRoleOption
+              active={session.role === 'vendor'}
+              label={t('roles.vendorBadge')}
+              description={t('roles.vendorSummary')}
+              onClick={() => handleRoleChange('vendor')}
+            />
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add a vendor mode option to the account role switcher sheet so it matches the importer mode card

## Testing
- npm run lint *(fails: missing dev dependency @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d639d73b28832486dd5e9088b39f67