### PR TITLE
Increase default logo size

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -20,7 +20,7 @@ export const Logo = ({
   return (
     <div
       className={cn(
-        'inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-teal to-blue',
+        'inline-flex h-14 w-14 items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-teal to-blue',
         wrapperClassName,
       )}
       style={wrapperStyle}


### PR DESCRIPTION
## Summary
- expand the default logo wrapper dimensions so the brand mark renders slightly larger across the app

## Testing
- npm run lint *(fails: Missing dependency @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63b91ae4c8324a3b193e7289bb407