### PR TITLE
Align theme palette with brand colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>ProList_Mini Importation</title>
     <meta name="description" content="Trust-first preorder app with escrow, countdown and pickup QR." />
     <meta name="author" content="ProList Mini" />
-    <meta name="theme-color" content="#0FBF6D" />
+    <meta name="theme-color" content="#0087C5" />
     
     <!-- PWA -->
     <link rel="icon" href="/icon-192.png" sizes="192x192" />

--- a/public/images/blender.svg
+++ b/public/images/blender.svg
@@ -5,7 +5,7 @@
     <rect x="150" y="200" width="100" height="50" rx="20" fill="#1E1E1E"/>
     <rect x="170" y="90" width="40" height="50" rx="12" fill="#87E1FF"/>
     <rect x="210" y="90" width="20" height="90" rx="10" fill="#C9F2FF"/>
-    <circle cx="200" cy="225" r="16" fill="#0FBF6D"/>
+    <circle cx="200" cy="225" r="16" fill="#0DB771"/>
     <circle cx="200" cy="225" r="8" fill="white"/>
   </g>
   <defs>
@@ -19,8 +19,8 @@
       <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
     </filter>
     <linearGradient id="paint0_linear" x1="80" y1="40" x2="340" y2="260" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#88D3FF"/>
-      <stop offset="1" stop-color="#1C5E9E"/>
+      <stop stop-color="#0EB4A3"/>
+      <stop offset="1" stop-color="#0087C5"/>
     </linearGradient>
   </defs>
 </svg>

--- a/public/images/charger.svg
+++ b/public/images/charger.svg
@@ -2,7 +2,7 @@
   <rect width="400" height="300" rx="28" fill="url(#paint0_linear)"/>
   <g filter="url(#filter0_d)">
     <rect x="140" y="70" width="120" height="160" rx="24" fill="white"/>
-    <rect x="160" y="90" width="80" height="40" rx="12" fill="#0FBF6D" opacity="0.85"/>
+    <rect x="160" y="90" width="80" height="40" rx="12" fill="#0DB771" opacity="0.85"/>
     <rect x="180" y="150" width="40" height="40" rx="8" fill="#E8F8EE"/>
     <rect x="185" y="200" width="30" height="10" rx="4" fill="#D1EEDF"/>
   </g>
@@ -19,8 +19,8 @@
       <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
     </filter>
     <linearGradient id="paint0_linear" x1="40" y1="20" x2="360" y2="280" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#0FBF6D"/>
-      <stop offset="1" stop-color="#0A8F77"/>
+      <stop stop-color="#0DB771"/>
+      <stop offset="1" stop-color="#0087C5"/>
     </linearGradient>
   </defs>
 </svg>

--- a/public/images/hair-clippers.svg
+++ b/public/images/hair-clippers.svg
@@ -4,7 +4,7 @@
     <rect x="170" y="70" width="60" height="140" rx="26" fill="white"/>
     <rect x="165" y="120" width="70" height="110" rx="28" fill="#1B1B1B"/>
     <rect x="180" y="85" width="40" height="30" rx="12" fill="#FFD166"/>
-    <rect x="186" y="200" width="28" height="28" rx="10" fill="#0FBF6D"/>
+    <rect x="186" y="200" width="28" height="28" rx="10" fill="#0DB771"/>
     <path d="M172 70H228L216 50H184L172 70Z" fill="#FFD166"/>
   </g>
   <defs>
@@ -18,8 +18,8 @@
       <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
     </filter>
     <linearGradient id="paint0_linear" x1="90" y1="40" x2="340" y2="260" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#6D5BFF"/>
-      <stop offset="1" stop-color="#3A1C71"/>
+      <stop stop-color="#0087C5"/>
+      <stop offset="1" stop-color="#0EB4A3"/>
     </linearGradient>
   </defs>
 </svg>

--- a/public/images/power-bank.svg
+++ b/public/images/power-bank.svg
@@ -3,8 +3,8 @@
   <g filter="url(#filter0_d)">
     <rect x="150" y="70" width="100" height="160" rx="30" fill="white"/>
     <rect x="170" y="90" width="60" height="40" rx="14" fill="#132D46"/>
-    <path d="M205 170L190 200H210L195 230" stroke="#0FBF6D" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
-    <rect x="188" y="118" width="24" height="6" rx="3" fill="#0FBF6D"/>
+    <path d="M205 170L190 200H210L195 230" stroke="#0DB771" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+    <rect x="188" y="118" width="24" height="6" rx="3" fill="#0DB771"/>
     <rect x="183" y="206" width="34" height="6" rx="3" fill="#BFDDED"/>
   </g>
   <defs>
@@ -18,8 +18,8 @@
       <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
     </filter>
     <linearGradient id="paint0_linear" x1="80" y1="40" x2="340" y2="260" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#1E3C72"/>
-      <stop offset="1" stop-color="#2A5298"/>
+      <stop stop-color="#0087C5"/>
+      <stop offset="1" stop-color="#0EB4A3"/>
     </linearGradient>
   </defs>
 </svg>

--- a/src/index.css
+++ b/src/index.css
@@ -7,27 +7,27 @@
 @layer base {
   :root {
     /* Brand Colors */
-    --color-primary: 152 85% 40%;          /* #0FBF6D */
-    --color-timer: 158 88% 35%;            /* #0AA66D */
-    --color-teal: 180 96% 33%;             /* #03A6A6 */
-    --color-blue: 191 96% 38%;             /* #049DBF */
-    --color-ocean: 197 96% 38%;            /* #048ABF */
+    --color-primary: 155 87% 38%;          /* #0DB771 */
+    --color-timer: 158 89% 35%;            /* #0AA66D */
+    --color-teal: 174 86% 38%;             /* #0EB4A3 */
+    --color-blue: 199 100% 39%;            /* #0087C5 */
+    --color-ocean: 198 100% 31%;           /* #006F9F */
 
     /* Base Colors */
-    --color-fg: 210 27% 12%;               /* #132235 */
-    --color-muted: 210 15% 46%;            /* #6E7C8B */
-    --color-bg: 210 20% 98%;               /* #F6F8FB */
+    --color-fg: 205 61% 15%;               /* #0F2A3D */
+    --color-muted: 204 23% 54%;            /* #6E8FA5 */
+    --color-bg: 194 76% 97%;               /* #F0FAFD */
     --color-card: 0 0% 100%;               /* #FFFFFF */
-    --color-border: 196 56% 86%;           /* #CFE8F4 */
+    --color-border: 198 66% 87%;           /* #C9E7F4 */
     --color-glass: 0 0% 100% / 0.78;
 
     /* Decorative tokens */
     --gradient-aurora:
-      radial-gradient(circle at 15% 15%, hsl(var(--color-blue) / 0.08), transparent 60%),
-      radial-gradient(circle at 85% 10%, hsl(var(--color-teal) / 0.06), transparent 60%),
-      radial-gradient(120% 120% at 80% 85%, hsl(var(--color-primary) / 0.05), transparent 55%);
-    --shadow-lux: 0 28px 60px -28px rgba(4, 154, 191, 0.55);
-    --shadow-glow: 0 18px 40px -16px rgba(15, 191, 109, 0.45);
+      radial-gradient(circle at 15% 15%, hsl(var(--color-blue) / 0.12), transparent 60%),
+      radial-gradient(circle at 85% 10%, hsl(var(--color-teal) / 0.1), transparent 60%),
+      radial-gradient(120% 120% at 80% 85%, hsl(var(--color-primary) / 0.08), transparent 55%);
+    --shadow-lux: 0 28px 60px -28px rgba(0, 135, 197, 0.5);
+    --shadow-glow: 0 18px 40px -16px rgba(13, 183, 113, 0.45);
     --font-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 
     /* Semantic tokens for shadcn compatibility */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig(({ mode }) => {
           name: 'ProList_Mini Importation',
           short_name: 'ProList Mini',
           description: 'Trust-first preorder app with escrow, countdown and pickup QR.',
-          theme_color: '#0FBF6D',
+          theme_color: '#0087C5',
           background_color: '#ffffff',
           display: 'standalone',
           start_url: base,


### PR DESCRIPTION
## Summary
- refresh the global CSS tokens so the UI primary, teal, and blue values match the turquoise-and-blue logo palette
- update the PWA meta and manifest theme colors to use the refreshed brand primary
- recolor the marketing illustrations to reuse the same gradient and accent fills

## Testing
- `npm run build` *(fails: vite executable unavailable before dependencies install)*

------
https://chatgpt.com/codex/tasks/task_e_68d911a2d5608324a02fac3b07c24099